### PR TITLE
New warning color (orange)

### DIFF
--- a/exampleApp/src/main/java/com/mercadolibre/android/ui/example/ui/widgets/SnackbarActivity.java
+++ b/exampleApp/src/main/java/com/mercadolibre/android/ui/example/ui/widgets/SnackbarActivity.java
@@ -46,6 +46,17 @@ public class SnackbarActivity extends BaseActivity {
                 .show();
     }
 
+    public void showOrangeSnackbar(View view) {
+        MeliSnackbar.make(view, "Feedback de warning", Snackbar.LENGTH_LONG, MeliSnackbar.SnackbarType.WARNING)
+                .setAction("Salida", new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        Toast.makeText(v.getContext(), "Dismiss!", Toast.LENGTH_LONG).show();
+                    }
+                })
+                .show();
+    }
+
     public void showBlackSnackbar(View view) {
         MeliSnackbar.make(view, "Mensaje genérico multilínea sin salida donde hay mucho texto", Snackbar.LENGTH_LONG)
                 .show();

--- a/exampleApp/src/main/res/layout/activity_colors.xml
+++ b/exampleApp/src/main/res/layout/activity_colors.xml
@@ -104,5 +104,14 @@
             android:background="@color/ui_meli_red"
             android:text="meli_red" />
 
+        <Button
+            android:id="@+id/meli_orange"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/meli_red"
+            android:layout_marginBottom="10dp"
+            android:background="@color/ui_meli_orange"
+            android:text="meli_orange" />
+
     </RelativeLayout>
 </ScrollView>

--- a/exampleApp/src/main/res/layout/activity_snackbar.xml
+++ b/exampleApp/src/main/res/layout/activity_snackbar.xml
@@ -42,6 +42,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
+            android:onClick="showOrangeSnackbar"
+            android:text="Warning snackbar" />
+
+        <Button
+            style="@style/Button.Action.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
             android:onClick="showBlackSnackbar"
             android:text="Message snackbar" />
 

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSnackbar.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSnackbar.java
@@ -54,12 +54,13 @@ public final class MeliSnackbar {
 
     @SuppressWarnings("PMD.RedundantFieldInitializer")
     @Retention(RetentionPolicy.SOURCE)
-    @IntDef({SnackbarType.MESSAGE, SnackbarType.SUCCESS, SnackbarType.ERROR})
+    @IntDef({SnackbarType.MESSAGE, SnackbarType.SUCCESS, SnackbarType.ERROR, SnackbarType.WARNING})
 
     public @interface SnackbarType {
         /* default */ int MESSAGE = 0;
         /* default */ int SUCCESS = 1;
         /* default */ int ERROR = 2;
+        /* default */ int WARNING = 3;
     }
 
     private MeliSnackbar(@NonNull final Snackbar snackbar, @SnackbarType final int type) {
@@ -71,6 +72,9 @@ public final class MeliSnackbar {
                 break;
             case SnackbarType.ERROR:
                 snackbarColor = R.color.ui_components_error_color;
+                break;
+            case SnackbarType.WARNING:
+                snackbarColor = R.color.ui_components_warning_color;
                 break;
             case SnackbarType.MESSAGE:
             default:

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="ui_components_secondary_color_text_disabled">#332681FF</color>
     <color name="ui_components_success_color">#39B54A</color>
     <color name="ui_components_error_color">#F04449</color>
+    <color name="ui_components_warning_color">#FBAB60</color>
     <color name="ui_components_black_color">#333333</color>
     <color name="ui_components_dark_grey_color">#666666</color>
     <color name="ui_components_grey_color">#999999</color>
@@ -39,11 +40,13 @@
     <color name="ui_meli_blue">#3483FA</color>
     <color name="ui_meli_green">#39B54A</color>
     <color name="ui_meli_red">#F04449</color>
+    <color name="ui_meli_orange">#FBAB60</color>
 
     <!-- Contextualized colors -->
     <color name="ui_meli_background">@color/ui_meli_light_grey</color>
     <color name="ui_meli_success">@color/ui_meli_green</color>
     <color name="ui_meli_error">@color/ui_meli_red</color>
+    <color name="ui_meli_warning">@color/ui_meli_orange</color>
     <color name="ui_ripple_mask">#1A333333</color>
 
     <color name="ui_transparent">#00000000</color>

--- a/ui/src/test/java/com/mercadolibre/android/ui/colors/ColorsTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/colors/ColorsTest.java
@@ -35,6 +35,7 @@ public class ColorsTest {
         assertColors(R.color.ui_meli_blue, "#3483FA");
         assertColors(R.color.ui_meli_green, "#39B54A");
         assertColors(R.color.ui_meli_red, "#F04449");
+        assertColors(R.color.ui_meli_orange, "#FBAB60");
     }
 
     @Test
@@ -43,6 +44,7 @@ public class ColorsTest {
                      ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_light_grey));
         assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_success), ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_green));
         assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_error), ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_red));
+        assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_warning), ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_orange));
     }
 
     private void assertColors(@ColorRes final int colorRes, final String colorString) {

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliSnackbarTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliSnackbarTest.java
@@ -155,7 +155,7 @@ public class MeliSnackbarTest {
 
     @Test
     public void testMessageType() {
-        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.Type.MESSAGE)
+        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.SnackbarType.MESSAGE)
                                                   .setAction(ACTION_STRING,
                                                              new View.OnClickListener() {
                                                                  @Override
@@ -168,16 +168,16 @@ public class MeliSnackbarTest {
         Assert.assertEquals(TEST_STRING, getTextView(snackbar).getText());
         Assert.assertEquals(Snackbar.LENGTH_INDEFINITE, getSnackbar(snackbar).getDuration());
         // Test background color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_black), getBackgroundColor(snackbar));
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_black_color), getBackgroundColor(snackbar));
         // Test text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getTextView(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getTextView(snackbar).getTextColors().getDefaultColor());
         // Test action text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getActionButton(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getActionButton(snackbar).getTextColors().getDefaultColor());
     }
 
     @Test
     public void testSuccessType() {
-        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.Type.SUCCESS)
+        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.SnackbarType.SUCCESS)
                                                   .setAction(ACTION_STRING,
                                                              new View.OnClickListener() {
                                                                  @Override
@@ -190,32 +190,53 @@ public class MeliSnackbarTest {
         Assert.assertEquals(TEST_STRING, getTextView(snackbar).getText());
         Assert.assertEquals(Snackbar.LENGTH_INDEFINITE, getSnackbar(snackbar).getDuration());
         // Test background color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_success), getBackgroundColor(snackbar));
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_success_color), getBackgroundColor(snackbar));
         // Test text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getTextView(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getTextView(snackbar).getTextColors().getDefaultColor());
         // Test action text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getActionButton(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getActionButton(snackbar).getTextColors().getDefaultColor());
     }
 
     @Test
     public void testErrorType() {
-        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.Type.ERROR)
-                                                  .setAction(ACTION_STRING, new View.OnClickListener() {
-                                                      @Override
-                                                      public void onClick(View v) {
-                                                          // Do nothing.
-                                                      }
-                                                  });
+        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.SnackbarType.ERROR)
+            .setAction(ACTION_STRING, new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    // Do nothing.
+                }
+            });
 
         Assert.assertNotNull(snackbar);
         Assert.assertEquals(TEST_STRING, getTextView(snackbar).getText());
         Assert.assertEquals(Snackbar.LENGTH_INDEFINITE, getSnackbar(snackbar).getDuration());
         // Test background color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_error), getBackgroundColor(snackbar));
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_error_color), getBackgroundColor(snackbar));
         // Test text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getTextView(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getTextView(snackbar).getTextColors().getDefaultColor());
         // Test action text color.
-        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_meli_white), getActionButton(snackbar).getTextColors().getDefaultColor());
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getActionButton(snackbar).getTextColors().getDefaultColor());
+    }
+
+    @Test
+    public void testWarningType() {
+        final MeliSnackbar snackbar = MeliSnackbar.make(view, TEST_STRING, Snackbar.LENGTH_INDEFINITE, MeliSnackbar.SnackbarType.WARNING)
+            .setAction(ACTION_STRING, new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    // Do nothing.
+                }
+            });
+
+        Assert.assertNotNull(snackbar);
+        Assert.assertEquals(TEST_STRING, getTextView(snackbar).getText());
+        Assert.assertEquals(Snackbar.LENGTH_INDEFINITE, getSnackbar(snackbar).getDuration());
+        // Test background color.
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_warning_color), getBackgroundColor(snackbar));
+        // Test text color.
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getTextView(snackbar).getTextColors().getDefaultColor());
+        // Test action text color.
+        Assert.assertEquals(ContextCompat.getColor(RuntimeEnvironment.application, R.color.ui_components_white_color), getActionButton(snackbar).getTextColors().getDefaultColor());
     }
 
     @Test


### PR DESCRIPTION
## Descripción
UX definió un nuevo color para la paleta. El color naranja (Orange) para los casos de escenarios que son Warnings.

## Cambios
- Se agrega un estado de **Warning** al **Snackbar** para que se pinte con el nuevo color **naranja**.
- Se agregan los colores: **ui_components_warning_color** (que se usa en el snackbar), **ui_meli_orange** (para la paleta de colores), **ui_meli_warning** (por compatibilidad)
- Se agregan tests para el nuevo color
- Se arreglan los tests del Snackbar para que testeen los nuevos componentes, y no usen más el código deprecado
- Se agrega el Snackbar naranja y el nuevo color a la app de ejemplos

<img width="258" alt="captura de pantalla 2018-05-08 a la s 14 04 58" src="https://user-images.githubusercontent.com/5674142/39771742-9f8ae4d6-52c9-11e8-8862-cee24358d8de.png">

<img width="259" alt="captura de pantalla 2018-05-08 a la s 14 05 23" src="https://user-images.githubusercontent.com/5674142/39771755-a56e462c-52c9-11e8-924a-c54fc51e1100.png">


## ¿Por qué necesitamos este cambio?
Estos cambios permiten la correcta implementación de la Lib de UI en PX.