### PR TITLE
[MLTheme] se modifican colores para poder compartirlo entre las apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.3.0
+- MLTheme deja de extender de MLThemeLegacy y ahora permite ser customizado
+
 ## v5.2.1
 - Fix font set on MeliButton
 - Dimens added

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=5.2.1
+libraryVersion=5.3.0
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/ui/src/main/res/values-v21/themes.xml
+++ b/ui/src/main/res/values-v21/themes.xml
@@ -1,21 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
+    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
+        <item name="android:windowBackground">@color/background_color</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
 
+        <item name="android:actionMenuTextColor">@color/gray_dark</item>
+
+        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
+        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
+
+        <item name="android:textViewStyle">@style/textview_default</item>
+        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+
+        <!--<item name="actionBarStyle">@style/Widget.ActionMode</item>-->
+        <item name="colorAccent">@color/ui_components_colorAccent</item>
+
+        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
+
+        <item name="android:colorPressedHighlight">@color/selection_color</item>
+        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
+        <!--<item name="colorPrimary">@color/blue</item>-->
+        <!--<item name="android:textColorSecondary">@color/blue</item>-->
+        <!--<item name="android:colorControlNormal">@color/blue</item>-->
+
+        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
+
+        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
+        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
+
+        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
+
+        <item name="actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
+        <!-- for native ActionBar -->
+        <item name="android:actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
+
+        <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
+
+        <item name="android:colorPrimary">@color/ui_components_colorPrimary</item>
+        <item name="android:colorPrimaryDark">@color/ui_components_colorPrimaryDark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="android:colorAccent">@color/ui_meli_blue</item>
+        <item name="android:colorAccent">@color/ui_components_colorAccent</item>
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>
 
-        <item name="android:actionModeBackground">@color/ui_meli_yellow</item>
-        <item name="actionModeBackground">@color/ui_meli_yellow</item>
+        <item name="android:actionModeBackground">@color/ui_components_actionModeBackground</item>
+        <item name="actionModeBackground">@color/ui_components_actionModeBackground</item>
 
         <!-- Line spacing -->
         <item name="android:lineSpacingExtra">2dp</item>

--- a/ui/src/main/res/values-v21/themes.xml
+++ b/ui/src/main/res/values-v21/themes.xml
@@ -22,39 +22,31 @@
 
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
 
-        <!--<item name="actionBarStyle">@style/Widget.ActionMode</item>-->
-        <item name="colorAccent">@color/ui_components_colorAccent</item>
-
         <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
 
         <item name="android:colorPressedHighlight">@color/selection_color</item>
         <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-        <!--<item name="colorPrimary">@color/blue</item>-->
-        <!--<item name="android:textColorSecondary">@color/blue</item>-->
-        <!--<item name="android:colorControlNormal">@color/blue</item>-->
 
         <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
 
-        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
         <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
 
         <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
 
         <item name="actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
-        <!-- for native ActionBar -->
         <item name="android:actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
 
         <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
 
-        <item name="android:colorPrimary">@color/ui_components_colorPrimary</item>
-        <item name="android:colorPrimaryDark">@color/ui_components_colorPrimaryDark</item>
+        <item name="android:colorPrimary">@color/ui_components_android_color_primary</item>
+        <item name="android:colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="android:colorAccent">@color/ui_components_colorAccent</item>
+        <item name="android:colorAccent">@color/ui_components_android_color_accent</item>
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>

--- a/ui/src/main/res/values-v21/themes.xml
+++ b/ui/src/main/res/values-v21/themes.xml
@@ -1,52 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
-        <item name="android:windowBackground">@color/background_color</item>
-        <item name="windowActionModeOverlay">true</item>
-        <item name="android:windowActionModeOverlay">true</item>
-        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
+    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
 
-        <item name="android:actionMenuTextColor">@color/gray_dark</item>
-
-        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
-        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
-
-        <item name="android:textViewStyle">@style/textview_default</item>
-        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
-
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
-
-        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
-
-        <item name="android:colorPressedHighlight">@color/selection_color</item>
-        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-
-        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
-
-        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
-
-        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
-
-        <item name="actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
-        <item name="android:actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
-
-        <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
-
-        <item name="android:colorPrimary">@color/ui_components_android_color_primary</item>
-        <item name="android:colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="android:colorAccent">@color/ui_components_android_color_accent</item>
+        <item name="colorAccent">@color/ui_components_android_color_accent</item>
+        <item name="colorPrimary">@color/ui_components_android_color_primary</item>
+        <item name="colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
+
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -46,15 +46,15 @@
 
         <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
 
-        <item name="android:colorPrimary">@color/ui_components_colorPrimary</item>
-        <item name="android:colorPrimaryDark">@color/ui_components_colorPrimaryDark</item>
+        <item name="android:colorPrimary">@color/ui_components_android_color_primary</item>
+        <item name="android:colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="colorAccent">@color/ui_components_colorAccent</item>
+        <item name="colorAccent">@color/ui_components_android_color_accent</item>
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -3,47 +3,8 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
 
-    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
+    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
 
-        <item name="android:windowBackground">@color/background_color</item>
-        <item name="windowActionModeOverlay">true</item>
-        <item name="android:windowActionModeOverlay">true</item>
-        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
-
-        <item name="android:actionMenuTextColor">@color/gray_dark</item>
-
-        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
-        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
-
-        <item name="android:textViewStyle">@style/textview_default</item>
-        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
-
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
-
-        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
-
-        <item name="android:colorPressedHighlight">@color/selection_color</item>
-        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-
-        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
-
-        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
-
-        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
-
-        <item name="actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
-        <!-- for native ActionBar -->
-        <item name="android:actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
-
-        <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
-
-        <item name="android:colorPrimary">@color/ui_components_android_color_primary</item>
-        <item name="android:colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
@@ -51,6 +12,8 @@
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
         <item name="colorAccent">@color/ui_components_android_color_accent</item>
+        <item name="colorPrimary">@color/ui_components_android_color_primary</item>
+        <item name="colorPrimaryDark">@color/ui_components_android_color_primary_dark</item>
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -29,13 +29,9 @@
 
         <item name="android:colorPressedHighlight">@color/selection_color</item>
         <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-        <!--<item name="colorPrimary">@color/blue</item>-->
-        <!--<item name="android:textColorSecondary">@color/blue</item>-->
-        <!--<item name="android:colorControlNormal">@color/blue</item>-->
 
         <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
 
-        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
         <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
 
         <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -3,15 +3,58 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
 
-    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
+    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
 
+        <item name="android:windowBackground">@color/background_color</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
+
+        <item name="android:actionMenuTextColor">@color/gray_dark</item>
+
+        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
+        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
+
+        <item name="android:textViewStyle">@style/textview_default</item>
+        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+
+        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
+
+        <item name="android:colorPressedHighlight">@color/selection_color</item>
+        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
+        <!--<item name="colorPrimary">@color/blue</item>-->
+        <!--<item name="android:textColorSecondary">@color/blue</item>-->
+        <!--<item name="android:colorControlNormal">@color/blue</item>-->
+
+        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
+
+        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
+        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
+
+        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
+
+        <item name="actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
+        <!-- for native ActionBar -->
+        <item name="android:actionBarItemBackground">?attr/selectableItemBackgroundBorderless</item>
+
+        <item name="selectableItemBackground">?android:attr/selectableItemBackground</item>
+
+        <item name="android:colorPrimary">@color/ui_components_colorPrimary</item>
+        <item name="android:colorPrimaryDark">@color/ui_components_colorPrimaryDark</item>
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
         <item name="android:buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="colorAccent">@color/ui_meli_blue</item>
+        <item name="colorAccent">@color/ui_components_colorAccent</item>
 
         <!-- Ripple mask color -->
         <item name="android:colorControlHighlight">@color/ui_ripple_mask</item>
@@ -23,8 +66,8 @@
         <item name="dialogTheme">@style/Theme.AppCompat.Light.Dialog.Alert</item>
         <item name="alertDialogTheme">@style/Theme.AppCompat.Light.Dialog.Alert</item>
 
-        <item name="android:actionModeBackground">@color/ui_meli_yellow</item>
-        <item name="actionModeBackground">@color/ui_meli_yellow</item>
+        <item name="android:actionModeBackground">@color/ui_components_actionModeBackground</item>
+        <item name="actionModeBackground">@color/ui_components_actionModeBackground</item>
 
         <!-- Line spacing -->
         <item name="android:lineSpacingExtra">2dp</item>

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -26,9 +26,9 @@
     <color name="ui_components_spinner_primary_color">@color/ui_components_primary_color</color>
     <color name="ui_components_spinner_secondary_color">@color/ui_base_color</color>
     <color name="ui_components_spinner_alternate_color">@color/ui_components_white_color</color>
-    <color name="ui_components_colorPrimary">@color/meli_yellow</color>
-    <color name="ui_components_colorPrimaryDark">#F5D315</color>
-    <color name="ui_components_colorAccent">@color/ui_meli_blue</color>
+    <color name="ui_components_android_color_primary">@color/meli_yellow</color>
+    <color name="ui_components_android_color_primary_dark">#F5D315</color>
+    <color name="ui_components_android_color_accent">@color/ui_meli_blue</color>
     <color name="ui_components_actionModeBackground">@color/ui_meli_yellow</color>
 
 

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -26,6 +26,10 @@
     <color name="ui_components_spinner_primary_color">@color/ui_components_primary_color</color>
     <color name="ui_components_spinner_secondary_color">@color/ui_base_color</color>
     <color name="ui_components_spinner_alternate_color">@color/ui_components_white_color</color>
+    <color name="ui_components_colorPrimary">@color/meli_yellow</color>
+    <color name="ui_components_colorPrimaryDark">#F5D315</color>
+    <color name="ui_components_colorAccent">@color/ui_meli_blue</color>
+    <color name="ui_components_actionModeBackground">@color/ui_meli_yellow</color>
 
 
     <!-- Meli Color palette -->

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -1,7 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
+    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
+
+        <item name="android:windowBackground">@color/background_color</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
+        <item name="android:actionMenuTextColor">@color/gray_dark</item>
+
+        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
+        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
+        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
+
+        <item name="android:textViewStyle">@style/textview_default</item>
+        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
+        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+
+        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
+
+        <item name="android:colorPressedHighlight">@color/selection_color</item>
+        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
+        <!--<item name="colorPrimary">@color/blue</item>-->
+        <!--<item name="android:textColorSecondary">@color/blue</item>-->
+        <!--<item name="android:colorControlNormal">@color/blue</item>-->
+
+        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
+
+        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
+        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
+
+        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
+
+        <item name="actionBarItemBackground">@drawable/actionbar_home_background</item>
+        <!-- for native ActionBar -->
+        <item name="android:actionBarItemBackground">@drawable/actionbar_home_background</item>
+
+        <item name="android:selectableItemBackground">@drawable/actionbar_home_background</item>
+        <item name="selectableItemBackground">@drawable/actionbar_home_background</item>
 
         <item name="android:textAppearance">@style/MLFont.Light</item>
 
@@ -9,10 +50,10 @@
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="colorAccent">@color/ui_meli_blue</item>
+        <item name="colorAccent">@color/ui_components_colorAccent</item>
 
-        <item name="android:actionModeBackground">@color/ui_meli_yellow</item>
-        <item name="actionModeBackground">@color/ui_meli_yellow</item>
+        <item name="android:actionModeBackground">@color/ui_components_actionModeBackground</item>
+        <item name="actionModeBackground">@color/ui_components_actionModeBackground</item>
 
         <item name="ui_meliSpinnerStyle">@style/ui_meli_spinner</item>
     </style>

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -26,13 +26,8 @@
 
         <item name="android:colorPressedHighlight">@color/selection_color</item>
         <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-        <!--<item name="colorPrimary">@color/blue</item>-->
-        <!--<item name="android:textColorSecondary">@color/blue</item>-->
-        <!--<item name="android:colorControlNormal">@color/blue</item>-->
-
         <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
 
-        <!--<item name="colorSwitchThumbNormal">@color/blue</item>-->
         <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
 
         <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -50,7 +50,7 @@
         <item name="buttonStyle">@style/Button.Action.Primary</item>
         <item name="buttonBarButtonStyle">@style/Button.Action.Primary</item>
 
-        <item name="colorAccent">@color/ui_components_colorAccent</item>
+        <item name="colorAccent">@color/ui_components_android_color_accent</item>
 
         <item name="android:actionModeBackground">@color/ui_components_actionModeBackground</item>
         <item name="actionModeBackground">@color/ui_components_actionModeBackground</item>

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -1,43 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.MLTheme" parent="@style/Theme.AppCompat.Light.NoActionBar" tools:ignore="ResourceName">
-
-        <item name="android:windowBackground">@color/background_color</item>
-        <item name="windowActionModeOverlay">true</item>
-        <item name="android:windowActionModeOverlay">true</item>
-        <item name="vpiCirclePageIndicatorStyle">@style/CustomCirclePageIndicator</item>
-        <item name="android:actionMenuTextColor">@color/gray_dark</item>
-
-        <item name="actionBarTabBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarStyle">@style/Widget.MLTheme.ActionBar</item>
-        <item name="actionBarTabStyle">@style/Widget.MLTheme.ActionBar.TabView</item>
-        <item name="actionBarTabTextStyle">@style/Widget.MLTheme.ActionBar.TabText</item>
-
-        <item name="android:textViewStyle">@style/textview_default</item>
-        <item name="android:progressBarStyle">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleHorizontal">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:progressBarStyleLarge">@style/Widget.MercadoLibre.ProgressBar.Horizontal</item>
-        <item name="android:scrollViewStyle">@style/Widget.ScrollView.Default</item>
-
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
-
-        <item name="android:actionBarSize">@dimen/abc_action_bar_default_height_material</item>
-
-        <item name="android:colorPressedHighlight">@color/selection_color</item>
-        <item name="android:colorLongPressedHighlight">@color/selection_color</item>
-        <item name="android:spinnerItemStyle">@style/MLSpinnerItem</item>
-
-        <item name="android:listSeparatorTextViewStyle">@style/MLPreference.ListHeader</item>
-
-        <item name="android:dropDownItemStyle">@style/MLDropDownItemStyle</item>
-
-        <item name="actionBarItemBackground">@drawable/actionbar_home_background</item>
-        <!-- for native ActionBar -->
-        <item name="android:actionBarItemBackground">@drawable/actionbar_home_background</item>
-
-        <item name="android:selectableItemBackground">@drawable/actionbar_home_background</item>
-        <item name="selectableItemBackground">@drawable/actionbar_home_background</item>
+    <style name="Theme.MLTheme" parent="@style/Theme.MLThemeLegacy" tools:ignore="ResourceName">
 
         <item name="android:textAppearance">@style/MLFont.Light</item>
 


### PR DESCRIPTION
Se pasa todo que existia en el MLThemeLegacy al MLTheme para poder ir matando lo legacy.
El MLTheme tiene como parent directo "@style/Theme.AppCompat.Light.NoActionBar"
se agregan los colores: 
"ui_components_colorPrimary"
"ui_components_colorPrimaryDark"
"ui_components_colorAccent"
"ui_components_actionModeBackground"

Estos colores se agregan para que los módulos que usen el MLTheme puedan ser customizados cuando se meten en MP y que no se vea con el amarillo de ML. Esto permite que los módulos no cambien el theme que usan simplemente del lado de la app tienen que definir los colores (por defecto los de ml)