### PR TITLE
Fixing memory leak in spinner

### DIFF
--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/LoadingSpinner.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/LoadingSpinner.java
@@ -92,6 +92,8 @@ public class LoadingSpinner extends View {
         updateColor();
 
         a.recycle();
+
+        setupAnimations();
     }
 
     /**
@@ -164,8 +166,6 @@ public class LoadingSpinner extends View {
             }
         });
 
-        sweepAnim.start();
-        startAnim.start();
     }
 
     /**
@@ -247,8 +247,9 @@ public class LoadingSpinner extends View {
      * Call this on activity start to begin animations
      */
     public void onStart() {
-        if (startAnim == null || !startAnim.isRunning()) {
-            setupAnimations();
+        if (!startAnim.isRunning()) {
+            sweepAnim.start();
+            startAnim.start();
         }
     }
 
@@ -267,11 +268,9 @@ public class LoadingSpinner extends View {
      * @param animator the animator to clean
      */
     private void cleanAnimator(final ValueAnimator animator) {
-        if (animator != null) {
             animator.cancel();
             animator.removeAllListeners();
             animator.removeAllUpdateListeners();
-        }
     }
 
     /**


### PR DESCRIPTION
## Descripción

El `LoadingSpinner` estaba leakeando memoria por lo siguiente: 
Existían listeners que no se estaban desattacheando de los animators. Como los listeners tienen implementaciones con clases anónimas mantienen relación con el contexto de la vista, y ese contexto nunca podía ser destruído.

<img width="330" alt="captura de pantalla 2018-07-31 a la s 11 05 34" src="https://user-images.githubusercontent.com/5674142/43540251-96dea9dc-959d-11e8-9cdc-f8f4fe7582b2.png">

Con estos cambios se inicializan los animators en el constructor, así se asegura que siempre que se haga el clean se borren los listeners correspondientes.

## ¿Por qué necesitamos este cambio?
Para que deje de leakear memoria