### PR TITLE
Status bar light - para  api level 23+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v5.6.2
+## Arreglado
+- Para android 23+ se muestra el status bar light (con icono oscuros).
+
 ## v5.6.1
 ## Arreglado
 - No publicó 5.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=5.6.1
+libraryVersion=5.6.2
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -36,6 +36,8 @@
         <item name="android:lineSpacingExtra">2dp</item>
 
         <item name="ui_meliSpinnerStyle">@style/ui_meli_spinner</item>
+
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Descripción
Desde Android 23+ se permite cambiar el color de los iconos del status bar. 
Agregamos el theme light para tener una mejor visibilidad de los iconos del status bar.

En ppio, no afecta a MP, porque no se esta usando este theme. 

## ¿Por qué necesitamos este cambio?
Por un lado, es una mejora de android M que no estabamos aprovechando. 
Por otro, al tener un nuevo drawer (muy claro), lo iconos del status bar no se visualizan.


|Antes|Despues|
|--|--|
|<img width="250" alt="captura de pantalla 2018-11-26 a la s 19 20 03" src="https://user-images.githubusercontent.com/20328301/49045635-58229680-f1b0-11e8-8db9-15ec70d860d0.png">|<img width="250" alt="captura de pantalla 2018-11-26 a la s 19 21 00" src="https://user-images.githubusercontent.com/20328301/49045680-74263800-f1b0-11e8-9cd7-693e8b3af693.png">|
|<img width="250" alt="captura de pantalla 2018-11-26 a la s 19 22 35" src="https://user-images.githubusercontent.com/20328301/49045764-b780a680-f1b0-11e8-9fc1-af38d2d76c52.png">|<img width="250" alt="captura de pantalla 2018-11-26 a la s 19 22 18" src="https://user-images.githubusercontent.com/20328301/49045775-c0717800-f1b0-11e8-8ad1-f290ffb135c0.png">

