### PR TITLE
Typeface helper + base theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.7.0
+## Nuevo
+- Se agrega un theme `Theme.Base` que tiene **temporalmente** como parent a `Theme.MLTheme`. Este theme se encuentra vacio para ser overwriteado por los configurators de apps correspondientes.
+- Se agrega una interfaz `TypefaceHelper.TypefaceSetter` que permite customizar el comportamiento de como el `TypefaceHelper` setea las fuentes, esto nos permite descoplarnos de `Calligraphy` para el seteo de las mismas y utilizar otros features availables como Downloadable Fonts o alguna imple propia.
+
 ## v5.6.2
 ## Arreglado
 - Para android 23+ se muestra el status bar light (con icono oscuros).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v5.6.2
+## Arreglado
+- Para android 23+ se muestra el status bar light (con icono oscuros).
+
 ## v5.6.1
 ## Arreglado
 - No publicó 5.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=5.6.1
+libraryVersion=5.6.2
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=BETARDO-5.6.2
+libraryVersion=5.7.0
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=5.6.2
+libraryVersion=BETARDO-5.6.2
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -38,8 +38,7 @@ public final class TypefaceHelper {
             }
 
             @Nullable
-            @Override
-            public Typeface createTypeface(@NonNull Context context, @Nullable Font font) {
+            private Typeface createTypeface(@NonNull Context context, @Nullable Font font) {
                 if (font == null) {
                     return null;
                 }
@@ -82,16 +81,6 @@ public final class TypefaceHelper {
     }
 
     /**
-     * Crates a typeface given a {@link Font}
-     * @param context   The context of execution
-     * @param font  The {@link Font} that contains the path
-     * @return          A Typeface from a custom font
-     */
-    private static Typeface createTypeface(final Context context, final Font font) {
-        return typefaceSetter.createTypeface(context, font);
-    }
-
-    /**
      * Setter for typeface
      */
     public interface TypefaceSetter {
@@ -111,15 +100,6 @@ public final class TypefaceHelper {
          * @param font to set
          */
         void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font);
-
-        /**
-         * Create a typeface
-         * @param context to use
-         * @param font to create a typeface for
-         * @return Typeface created, null otherwise
-         */
-        @Nullable
-        Typeface createTypeface(@NonNull final Context context, @Nullable final Font font);
 
     }
 

--- a/ui/src/main/res/values-v23/themes.xml
+++ b/ui/src/main/res/values-v23/themes.xml
@@ -36,6 +36,8 @@
         <item name="android:lineSpacingExtra">2dp</item>
 
         <item name="ui_meliSpinnerStyle">@style/ui_meli_spinner</item>
+
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
 </resources>

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -17,4 +17,6 @@
         <item name="ui_meliSpinnerStyle">@style/ui_meli_spinner</item>
     </style>
 
+    <style name="Theme.Base" parent="Theme.MLTheme" tools:ignore="ResourceName" />
+
 </resources>


### PR DESCRIPTION
## Descripción

Se agrega:
1. Un `Theme.Base` este Theme va a reemplazar al MLTheme, estando vacio y siendo overrideado por las aplicaciones seteando lo que gusten.
2. Se hace el Typeface Helper custom, permitiendo agregar un setter interno para elegir como va a funcionar (por default funciona con calligraphy, pero podemos overridearlo y por ejemplo hacer que use downloadable fonts o lo que querramos)