### PR TITLE
Fixeamos el formato del chagelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,47 +1,47 @@
-## v5.7.1
+# v5.7.1
 ## Agregado
 - Se agrega metodo a TypefaceHelper para obtener un typeface. `#getTypeface(context, font, fontCallback)`. El mismo se recibe desde el callback ya que dependiendo de la imple puede ser sincronico o asincronico el fetch
 
-## v5.7.0
+# v5.7.0
 ## Nuevo
 - Se agrega un theme `Theme.Base` que tiene **temporalmente** como parent a `Theme.MLTheme`. Este theme se encuentra vacio para ser overwriteado por los configurators de apps correspondientes.
 - Se agrega una interfaz `TypefaceHelper.TypefaceSetter` que permite customizar el comportamiento de como el `TypefaceHelper` setea las fuentes, esto nos permite descoplarnos de `Calligraphy` para el seteo de las mismas y utilizar otros features availables como Downloadable Fonts o alguna imple propia.
 
-## v5.6.2
+# v5.6.2
 ## Arreglado
 - Para android 23+ se muestra el status bar light (con icono oscuros).
 
-## v5.6.1
+# v5.6.1
 ## Arreglado
 - No publicó 5.6.0
 
-## v5.6.0 
+# v5.6.0 
 ### Arreglado
 - Fix memory leak en el MeliSpinner
 
-## v5.5.1
+# v5.5.1
 ### Arreglado
 - No incluye nada, es una publicación para limpiar el delta de commits de develop para que no parezca que hay que relseasearla.
 
-## v5.5.0
+# v5.5.0
 ### Nuevo
 - Se agregaron otros 3 colores para poder customizar el theme desde las apps.
 
-## v5.4.1
+# v5.4.1
 - MLTheme customizations added
 
-## v5.4.0
+# v5.4.0
 - MLTheme ahora permite ser customizado
 
-## v5.3.0
+# v5.3.0
 - MLTheme deja de extender de MLThemeLegacy y ahora permite ser customizado
 
-## v5.2.1
+# v5.2.1
 - Fix font set on MeliButton
 - Dimens added
 
-## v5.2.0
+# v5.2.0
 - Changes
 
-## v5.1.0
+# v5.1.0
 - Turn on CircleCI 


### PR DESCRIPTION
## Descripción
Eso.

## ¿Por qué necesitamos este cambio?
Para estar alineado al resto de los proyectos