### PR TITLE
Fixing weird TextField keyboard behaviour and restore instance when configuration changed

### DIFF
--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -28,10 +28,8 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -43,7 +41,6 @@ import com.mercadolibre.android.ui.font.TypefaceHelper;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.mercadolibre.android.ui.widgets.TextField.type.CENTER;
 import static com.mercadolibre.android.ui.widgets.TextField.type.LEFT;
 import static java.lang.Integer.MAX_VALUE;
@@ -160,8 +157,6 @@ public final class TextField extends LinearLayout {
         initDefaults(context, a);
 
         a.recycle();
-
-
     }
 
     private void initDefaults(@NonNull final Context context, @NonNull final TypedArray a) {
@@ -231,14 +226,6 @@ public final class TextField extends LinearLayout {
 
         setHelper(helperText);
 
-        input.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(final View arg0, final MotionEvent arg1) {
-                showSoftKeyboard();
-                return false;
-            }
-        });
-
         input.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(final CharSequence s, final int start, final int count, final int after) {
@@ -287,8 +274,8 @@ public final class TextField extends LinearLayout {
         } else {
             label.setText(labelText);
             label.setVisibility(View.VISIBLE);
+            setHintAnimationEnabled(false);
         }
-        setHintAnimationEnabled(textIsEmpty);
 
         final LinearLayout.LayoutParams params =
                 (LinearLayout.LayoutParams) label.getLayoutParams();
@@ -562,15 +549,6 @@ public final class TextField extends LinearLayout {
     }
 
     /**
-     * Check if the view is focused
-     *
-     * @return true if the view is focused, false otherwise
-     */
-    public boolean isFocused() {
-        return super.isFocused() || input.isFocused() || container.isFocused();
-    }
-
-    /**
      * Adds a TextWatcher to the list of those whose methods are called
      * whenever this TextView's text changes.
      *
@@ -813,16 +791,6 @@ public final class TextField extends LinearLayout {
             container.setEnabled(false);
             setCharactersCountVisible(false);
             setError(null);
-        }
-    }
-
-    /**
-     * Shows the soft keyboard
-     */
-    /* default */ void showSoftKeyboard() {
-        if (isEnabled()) {
-            ((InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE))
-                    .showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
         }
     }
 

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
@@ -9,14 +9,10 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.os.SystemClock;
 import android.support.design.widget.TextInputLayout;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.Gravity;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -51,7 +47,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -418,35 +413,6 @@ public class TextFieldTest {
         assertFalse(container.isFocusableInTouchMode());
         assertFalse(container.isEnabled());
         assertFalse(container.isCounterEnabled());
-    }
-
-    @Test
-    public void testOnTouch_shouldOpenKeyboard() {
-        Context context = spy(this.context);
-        InputMethodManager imm = mock(InputMethodManager.class);
-
-        doReturn(imm).when(context).getSystemService(Context.INPUT_METHOD_SERVICE);
-        doReturn(true).when(imm).showSoftInput(any(View.class), anyInt());
-
-        final long downTime = SystemClock.uptimeMillis();
-        final long eventTime = SystemClock.uptimeMillis() + 100;
-        final float x = 0.0f;
-        final float y = 0.0f;
-        // List of meta states found here: developer.android.com/reference/android/view/KeyEvent.html#getMetaState()
-        final int metaState = 0;
-        final MotionEvent motionEvent = MotionEvent.obtain(
-                downTime,
-                eventTime,
-                MotionEvent.ACTION_UP,
-                x,
-                y,
-                metaState
-        );
-
-        final TextField spyTextField = new TextField(context);
-        spyTextField.getEditText().dispatchTouchEvent(motionEvent);
-
-        verify(imm).showSoftInput(any(View.class), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Descripción
```
    /**
     * Check if the view is focused
     *
     * @return true if the view is focused, false otherwise
     */
    public boolean isFocused() {
        return super.isFocused() || input.isFocused() || container.isFocused();
    }
```

## ¿Por qué necesitamos este cambio?