### PR TITLE
Fixing weird TextField keyboard behaviour and restore instance when configuration changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.10.1
+## Arreglado
+- Se corrige el comportamiento del teclado cuando el componente `TextField` toma el foco.
+- Se corrige la reconstrución de la instancia del componente `TextField` cuando ocurre un cambio de configuración.
+
 # v5.10.0
 ## Nuevo
 - Se agrega el color ui_components_action_bar_text_color a la paleta.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 project_name=ui
 
 libraryGroup=com.mercadolibre.android
-libraryVersion=5.10.0
+libraryVersion=5.10.1
 
 minSdkApiVersion=14
 targetSdkApiVersion=27

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -28,10 +28,8 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -43,7 +41,6 @@ import com.mercadolibre.android.ui.font.TypefaceHelper;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.mercadolibre.android.ui.widgets.TextField.type.CENTER;
 import static com.mercadolibre.android.ui.widgets.TextField.type.LEFT;
 import static java.lang.Integer.MAX_VALUE;
@@ -160,8 +157,6 @@ public final class TextField extends LinearLayout {
         initDefaults(context, a);
 
         a.recycle();
-
-
     }
 
     private void initDefaults(@NonNull final Context context, @NonNull final TypedArray a) {
@@ -231,14 +226,6 @@ public final class TextField extends LinearLayout {
 
         setHelper(helperText);
 
-        input.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(final View arg0, final MotionEvent arg1) {
-                showSoftKeyboard();
-                return false;
-            }
-        });
-
         input.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(final CharSequence s, final int start, final int count, final int after) {
@@ -287,8 +274,8 @@ public final class TextField extends LinearLayout {
         } else {
             label.setText(labelText);
             label.setVisibility(View.VISIBLE);
+            setHintAnimationEnabled(false);
         }
-        setHintAnimationEnabled(textIsEmpty);
 
         final LinearLayout.LayoutParams params =
                 (LinearLayout.LayoutParams) label.getLayoutParams();
@@ -562,15 +549,6 @@ public final class TextField extends LinearLayout {
     }
 
     /**
-     * Check if the view is focused
-     *
-     * @return true if the view is focused, false otherwise
-     */
-    public boolean isFocused() {
-        return super.isFocused() || input.isFocused() || container.isFocused();
-    }
-
-    /**
      * Adds a TextWatcher to the list of those whose methods are called
      * whenever this TextView's text changes.
      *
@@ -813,16 +791,6 @@ public final class TextField extends LinearLayout {
             container.setEnabled(false);
             setCharactersCountVisible(false);
             setError(null);
-        }
-    }
-
-    /**
-     * Shows the soft keyboard
-     */
-    /* default */ void showSoftKeyboard() {
-        if (isEnabled()) {
-            ((InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE))
-                    .showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
         }
     }
 

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
@@ -9,14 +9,10 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.os.SystemClock;
 import android.support.design.widget.TextInputLayout;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.Gravity;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -51,7 +47,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -418,35 +413,6 @@ public class TextFieldTest {
         assertFalse(container.isFocusableInTouchMode());
         assertFalse(container.isEnabled());
         assertFalse(container.isCounterEnabled());
-    }
-
-    @Test
-    public void testOnTouch_shouldOpenKeyboard() {
-        Context context = spy(this.context);
-        InputMethodManager imm = mock(InputMethodManager.class);
-
-        doReturn(imm).when(context).getSystemService(Context.INPUT_METHOD_SERVICE);
-        doReturn(true).when(imm).showSoftInput(any(View.class), anyInt());
-
-        final long downTime = SystemClock.uptimeMillis();
-        final long eventTime = SystemClock.uptimeMillis() + 100;
-        final float x = 0.0f;
-        final float y = 0.0f;
-        // List of meta states found here: developer.android.com/reference/android/view/KeyEvent.html#getMetaState()
-        final int metaState = 0;
-        final MotionEvent motionEvent = MotionEvent.obtain(
-                downTime,
-                eventTime,
-                MotionEvent.ACTION_UP,
-                x,
-                y,
-                metaState
-        );
-
-        final TextField spyTextField = new TextField(context);
-        spyTextField.getEditText().dispatchTouchEvent(motionEvent);
-
-        verify(imm).showSoftInput(any(View.class), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Descripción
El **primer problema** consiste en que cuando se redefine el comportamiento del método `isFocused` provoca un error en el flujo que tiene Android implementado cuando una `View` se adjuta a un `ViewGroup`, debajo detallo esto.

Cuando una `View` se adjunta a un `ViewGroup` sucede esto:
````
at com.mercadolibre.android.ui.widgets.TextField.isFocused(TextField.java:570)
        at android.view.View.onAttachedToWindow(View.java:17829)
        at android.view.ViewGroup.onAttachedToWindow(ViewGroup.java:4956)
        at android.view.View.dispatchAttachedToWindow(View.java:18347)
````
En la implentación actual:
https://github.com/mercadolibre/fury_mobile-android-ui/blob/e9b8756a6045434b0b4dee72ade6144723d81678/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java#L569-L571

Se consulta por el foco de todos los componentes internos que tiene el `TextField`. Como Android en su comportamiento nativo siempre intenta darle el `focus` al primer elemento que sea `focusable`, entonces este método devuelve `true`cuando se trata del primer elemento, debido a que el `input` es un componente `focusable` y cuando es el primer elemento, entonces este toma el `focus`. En las imágenes de abajo se puede apreciar.

![image](https://user-images.githubusercontent.com/49170199/55670039-9a8e6b00-5855-11e9-9798-55f53eff2cfb.png)
![image](https://user-images.githubusercontent.com/49170199/55670057-fa851180-5855-11e9-812e-1dbea1a26d99.png)

Partiendo de que este método devuelve `true` cuando se trata del primer elemento, esto provoca que que el `InputMethodManager` actue sobre la vista actual (TextField o LinearLayout), porque así está definido en la implementación de `View`

```
 protected void onAttachedToWindow() {
        if ((mPrivateFlags & PFLAG_REQUEST_TRANSPARENT_REGIONS) != 0) {
            mParent.requestTransparentRegion(this);
        }

        mPrivateFlags3 &= ~PFLAG3_IS_LAID_OUT;

        jumpDrawablesToCurrentState();

        resetSubtreeAccessibilityStateChanged();

        // rebuild, since Outline not maintained while View is detached
        rebuildOutline();

        if (isFocused()) {
            InputMethodManager imm = InputMethodManager.peekInstance();
            if (imm != null) {
                imm.focusIn(this);
            }
        }
}
```
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/View.java#17933

Esto provoca que cuando se haga `tap`sobre el `TextField` no se muestre el `softKeyboard`, ya que antes ya había actuado sobre esa vista y por tanto, no es necesario "volverlo a mostrar". 

Si eliminamos este método, el `TextField` se comporta como debería ser y por tanto, ya no es necesario forzar la muestra del `softKeyboard`, responsabilidad que debería solo de Android.

El **segundo problema** consiste en la restauración de la instancia cuando ocurre un cambio en la configuración (ej. rotación de pantalla). En la implementación actual, cuando se realiza la restauración de la instancia se vuelve a inicializar todos los valores del componente.

https://github.com/mercadolibre/fury_mobile-android-ui/blob/e9b8756a6045434b0b4dee72ade6144723d81678/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java#L840-L856

Esto provoca que se llame a su vez el método `setLabel`

https://github.com/mercadolibre/fury_mobile-android-ui/blob/e9b8756a6045434b0b4dee72ade6144723d81678/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java#L840-L856

Por tanto, si en la configuración inicial no se especificó un `label` y la animación del `hint` **no** estaba habilitada, esto provoca que se habilite, debido a la implementación actual del método `setLabel`:

https://github.com/mercadolibre/fury_mobile-android-ui/blob/e9b8756a6045434b0b4dee72ade6144723d81678/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java#L282-L291

Es por ello, que ahora se cambió dicha implementación y solo se deshabilita la animación del `hint` solo cuando se especifica un `label`. De esta forma, si el componente no tenía `label` animación del `hint` continúa como mismo estaba antes, si tenía `label`, entonces se deshabilita, que es el comportamiento esperado.

## ¿Por qué necesitamos este cambio?
El cambio es necesario para corregir el comportamiento raro que ocurre con el `softKeyboard`, ya que si se fuerza que se muestre, el teclado no muestra las sugerencias, debido a que este comportamiento es propio de Android y solo el framework debería manejarlo.

Además, es necesario que cuando ocurra un cambio de configuración, se restaure correctamente la instancia del componente, lo cual no ocurría en ciertos casos, estos fueron descritos anteriormente.

## Videos del comportamiento antes y después
#### Primer problema - Comportamiento del `softKeyboard`
Antes | Después
----|----
![keyboard-sin-sugerencias](https://user-images.githubusercontent.com/49170199/55670515-ba289200-585b-11e9-97ea-b912b5eae9d2.gif) | ![keyboard-con-sugerencias](https://user-images.githubusercontent.com/49170199/55670511-abda7600-585b-11e9-80fc-2fd62d64ae3b.gif)

#### Segundo problema - Restaurando la instancia del componente
Antes | Después
----|----
![hint-con-error](https://user-images.githubusercontent.com/49170199/55670641-7fbff480-585d-11e9-8a19-4ce08353d861.gif) | ![hint-sin-error](https://user-images.githubusercontent.com/49170199/55670660-a9791b80-585d-11e9-908d-b85d006f7f3b.gif)







