### PR TITLE
[FIX] - Leak en MeliSpinner/LoadingSpinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,6 @@
 # v6.0.1
 ## Cambiado
 - Downgraded Bintray Plugin version.
-- Downgraded Gradle version.r
-
-# v6.0.0
-## Cambiado
-- Se sube el min API level al que usamos (16)
-- Actualización de dependencias
-- Actualización de Gradle 4.10.3
-- Se cambia el package de `com.mercadolibre.android.ui.widgets.animationManager` a `com.mercadolibre.android.ui.widgets.animationmanager` por un lint de PMD
-- Migración a API 28 y Support Library 28.0.0
-
-# v6.0.1
-## Cambiado
-- Downgraded Bintray Plugin version.
 - Downgraded Gradle version.
 
 # v6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# v6.0.2
+## Cambiado
+- MeliSpinner autostart attr deprecado.
+- MeliSpinner.start() y MeliSpinner.stop deprecado.
+- MeliSpinner controla ciclo de animacion basandose en onAttachedToWindow / onDetachedFromWindow
+- LoadingSpinner ahora solo agrega listener de animations cuando se va ejecutar la animacion y no en su constructor para prevenir leaks de memoria.
+
+# v6.0.1
+## Cambiado
+- Downgraded Bintray Plugin version.
+- Downgraded Gradle version.r
+
+# v6.0.0
+## Cambiado
+- Se sube el min API level al que usamos (16)
+- Actualización de dependencias
+- Actualización de Gradle 4.10.3
+- Se cambia el package de `com.mercadolibre.android.ui.widgets.animationManager` a `com.mercadolibre.android.ui.widgets.animationmanager` por un lint de PMD
+- Migración a API 28 y Support Library 28.0.0
+
 # v6.0.1
 ## Cambiado
 - Downgraded Bintray Plugin version.
@@ -16,7 +36,6 @@
 - Se agrega dialogo que se muestra en pantalla completa y con nuevo estilo
 
 # v5.10.1
-
 ## Eliminado
 - Cosas de los build.gradle que están de más.
 ## Arreglado

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=6.0.1
+libraryVersion=6.0.2
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/LoadingSpinner.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/LoadingSpinner.java
@@ -36,17 +36,17 @@ public class LoadingSpinner extends View {
     private Paint primaryColor;
     private Paint secondaryColor;
 
-    /* default */int sweepAngle;
-    /* default */ int startAngle;
+    private int sweepAngle;
+    private int startAngle;
 
     private int strokeSize;
 
     private RectF viewBounds;
     private Paint currentColor;
 
-    /* default */ ValueAnimator sweepAnim;
-    /* default */ ValueAnimator startAnim;
-    /* default */ ValueAnimator finalAnim;
+    private ValueAnimator sweepAnim;
+    private ValueAnimator startAnim;
+    private ValueAnimator finalAnim;
 
     /**
      * Default constructor to use by code
@@ -80,20 +80,19 @@ public class LoadingSpinner extends View {
     }
 
     private void init(final AttributeSet attrs, final int defStyleAttr) {
-        final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.LoadingSpinner, defStyleAttr, 0);
+        bindAttrs(attrs, defStyleAttr);
+        updateColor();
+        createAnimators();
+    }
 
+    private void bindAttrs(AttributeSet attrs, int defStyleAttr) {
+        final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.LoadingSpinner, defStyleAttr, 0);
         final int primaryColorInt = loadColor(a, R.styleable.LoadingSpinner_ui_primaryColor, R.color.ui_meli_blue);
         final int secondaryColorInt = loadColor(a, R.styleable.LoadingSpinner_ui_secondaryColor, R.color.ui_meli_yellow);
         strokeSize = a.getDimensionPixelSize(R.styleable.LoadingSpinner_ui_stroke, getResources().getDimensionPixelSize(R.dimen.ui_spinner_stroke));
-
         primaryColor = createPaint(Paint.Style.STROKE, strokeSize, primaryColorInt);
         secondaryColor = createPaint(Paint.Style.STROKE, strokeSize, secondaryColorInt);
-
-        updateColor();
-
         a.recycle();
-
-        setupAnimations();
     }
 
     /**
@@ -119,11 +118,10 @@ public class LoadingSpinner extends View {
     /**
      * Configure the animations that interpolate the arc values to achieve the loading effect
      */
-    private void setupAnimations() {
-        final int duration = getResources().getInteger(R.integer.ui_spinner_spinning_time);
+    private void setupListeners() {
+        cleanListeners();
 
         // - Head and tail start together, when the head finishes the full spin the tail catches up - //
-        sweepAnim = createAnimator(0, FULL_CIRCLE, duration);
         sweepAnim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(final ValueAnimator animation) {
@@ -131,7 +129,6 @@ public class LoadingSpinner extends View {
             }
         });
 
-        startAnim = createAnimator(0, QUARTER_CIRCLE, duration);
         startAnim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(final ValueAnimator animation) {
@@ -140,7 +137,7 @@ public class LoadingSpinner extends View {
             }
         });
 
-        finalAnim = createAnimator(QUARTER_CIRCLE, FULL_CIRCLE, duration);
+
         finalAnim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(final ValueAnimator animation) {
@@ -148,6 +145,7 @@ public class LoadingSpinner extends View {
                 invalidate();
             }
         });
+
         finalAnim.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(final Animator animation) {
@@ -248,6 +246,7 @@ public class LoadingSpinner extends View {
      */
     public void onStart() {
         if (!startAnim.isRunning()) {
+            setupListeners();
             sweepAnim.start();
             startAnim.start();
         }
@@ -257,9 +256,7 @@ public class LoadingSpinner extends View {
      * Call this on activity stop to finish animations
      */
     public void onStop() {
-        cleanAnimator(startAnim);
-        cleanAnimator(sweepAnim);
-        cleanAnimator(finalAnim);
+        cleanListeners();
     }
 
     /**
@@ -317,5 +314,18 @@ public class LoadingSpinner extends View {
                 + ", startAnim=" + startAnim
                 + ", finalAnim=" + finalAnim
                 + '}';
+    }
+
+    private void cleanListeners() {
+        cleanAnimator(sweepAnim);
+        cleanAnimator(startAnim);
+        cleanAnimator(finalAnim);
+    }
+
+    private void createAnimators() {
+        final int duration = getResources().getInteger(R.integer.ui_spinner_spinning_time);
+        sweepAnim = createAnimator(0, FULL_CIRCLE, duration);
+        startAnim = createAnimator(0, QUARTER_CIRCLE, duration);
+        finalAnim = createAnimator(QUARTER_CIRCLE, FULL_CIRCLE, duration);
     }
 }

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSpinner.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSpinner.java
@@ -98,12 +98,16 @@ public class MeliSpinner extends FrameLayout {
             setSpinnerMode(mode);
         }
 
-        final boolean autostart = a.getBoolean(R.styleable.MeliSpinner_autostart, true);
-
         a.recycle();
-        if (autostart) {
-            start();
-        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onAttachedToWindow() {
+        spinner.onStart();
+        super.onAttachedToWindow();
     }
 
     /**
@@ -111,7 +115,7 @@ public class MeliSpinner extends FrameLayout {
      */
     @Override
     protected void onDetachedFromWindow() {
-        stop();
+        spinner.onStop();
         super.onDetachedFromWindow();
     }
 
@@ -170,16 +174,18 @@ public class MeliSpinner extends FrameLayout {
 
     /**
      * Starts the spinner.
+     * @deprecated No longer necessary. Spinner start/stop automatically.
      */
+    @Deprecated
     public void start() {
-        spinner.onStart();
     }
 
     /**
      * Stops the spinner.
+     * @deprecated No longer necessary. Spinner start/stop automatically.
      */
+    @Deprecated
     public void stop() {
-        spinner.onStop();
     }
 
     private void configureSpinner(@ColorRes final int primaryColor, @ColorRes final int secondaryColor) {

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSpinner.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSpinner.java
@@ -178,6 +178,8 @@ public class MeliSpinner extends FrameLayout {
      */
     @Deprecated
     public void start() {
+        // Start is automatic since 6.0.2
+        // Method only maintained for retro compatibility
     }
 
     /**
@@ -186,6 +188,8 @@ public class MeliSpinner extends FrameLayout {
      */
     @Deprecated
     public void stop() {
+        // Stop is automatic since 6.0.2
+        // Method only maintained for retro compatibility
     }
 
     private void configureSpinner(@ColorRes final int primaryColor, @ColorRes final int secondaryColor) {

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -18,7 +18,6 @@
     <declare-styleable name="MeliSpinner">
         <attr name="spinnerText" format="string" />
         <attr name="textDelay" format="integer" />
-        <attr name="autostart" format="boolean" />
         <attr name="textFadeInDuration" format="integer" />
 
         <attr name="size" format="enum">


### PR DESCRIPTION
## Descripción
Se reporto un leak de memoria relacionado con el MeliSpinner. Este ocurre cuando se crea un MeliSpinner pero este no se agrega a una vista o bien se agrega pero se remueve antes de que se dibuje en pantalla. 
Esto ocurre dado que en el LoadingSpinner los animators listeners se agregan cuando el objeto se crea y no cuando realmente se necesitan (que es cuando se quiere inciar la animacion.

## ¿Por qué necesitamos este cambio?
Para aumentar la performance de la App y reducir el uso indiscriminado de memoria.

## FIX
Se modifico el codigo para que el MeliSpinner inicie la animacion al attacharse. Ya se detenia al desattacharse.