### PR TITLE
Reverting dependencies implementation

### DIFF
--- a/ui_legacy/build.gradle
+++ b/ui_legacy/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation "org.apache.commons:commons-lang3:$apacheCommonsVersion"
+    api "org.apache.commons:commons-lang3:$apacheCommonsVersion"
 
-    implementation "com.facebook.fresco:fresco:$frescoVersion"
+    api "com.facebook.fresco:fresco:$frescoVersion"
 }


### PR DESCRIPTION
## Descripción
Reverting dependencies implementation

## ¿Por qué necesitamos este cambio?
Because we weren't able to resolve them transitively