### PR TITLE
Add support for size in MeliButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#7.1.0
+## Agregado
+- Se agrega soporte al caso de `Small` para MeliButton, segun Andes.
+
 #7.0.0
 ## Arreglado
 - Se vuelve a agregar el attr autostart en MeliSpinner por retro compatibilidad

--- a/exampleApp/src/main/res/layout/activity_buttons_new.xml
+++ b/exampleApp/src/main/res/layout/activity_buttons_new.xml
@@ -70,5 +70,15 @@
             app:type="optionPrimary"
             app:state="disable"/>
 
+        <com.mercadolibre.android.ui.widgets.MeliButton
+            android:id="@+id/small"
+            style="@style/Button.Action.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/primary_option_disabled_button"
+            android:layout_marginBottom="10dp"
+            android:text="Small button"
+            app:button_size="small"/>
+
     </LinearLayout>
 </ScrollView>

--- a/exampleApp/src/main/res/layout/activity_buttons_new.xml
+++ b/exampleApp/src/main/res/layout/activity_buttons_new.xml
@@ -7,8 +7,7 @@
     android:background="@color/ui_components_white_color"
     tools:context="com.mercadolibre.android.ui.example.ui.widgets.ButtonsActivity">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="16dp"
@@ -71,14 +70,34 @@
             app:state="disable"/>
 
         <com.mercadolibre.android.ui.widgets.MeliButton
-            android:id="@+id/small"
-            style="@style/Button.Action.Primary"
+            android:id="@+id/small_action_enabled_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/primary_option_disabled_button"
             android:layout_marginBottom="10dp"
-            android:text="Small button"
-            app:button_size="small"/>
+            android:text="Small Primary action button enabled"
+            app:button_size="small"
+            app:state="normal"
+            app:type="actionPrimary" />
+
+        <com.mercadolibre.android.ui.widgets.MeliButton
+            android:id="@+id/small_secondary_action_enabled_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:text="Secondary action button enabled"
+            app:button_size="small"
+            app:type="actionSecondary"
+            app:state="normal"/>
+
+        <com.mercadolibre.android.ui.widgets.MeliButton
+            android:id="@+id/small_primary_option_enabled_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:text="Option button enabled"
+            app:button_size="small"
+            app:type="optionPrimary"
+            app:state="normal"/>
 
     </LinearLayout>
 </ScrollView>

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=7.0.0
+libraryVersion=7.1.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
@@ -45,7 +45,7 @@ public final class MeliButton extends AppCompatButton {
     @Type
     private int type;
     /**
-     * The type of button (Large, Small)
+     * The size of button {@link Size}
      */
     @Size
     private int size;
@@ -148,12 +148,13 @@ public final class MeliButton extends AppCompatButton {
                 sizeDimen = R.dimen.ui_fontsize_medium;
                 minHeightDimen = R.dimen.ui_button_height;
         }
-        //setMinHeight(getResources().getDimensionPixelSize(minHeightDimen));
-        setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimensionPixelSize(sizeDimen));
+
+        setMinHeight(getResources().getDimensionPixelSize(minHeightDimen));
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(sizeDimen));
     }
 
     /*
-        This was modified to reach exactly 48dp in height.
+        This was modified to reach exactly 48dp/36dp in height.
      */
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
@@ -2,7 +2,6 @@ package com.mercadolibre.android.ui.widgets;
 
 import android.content.Context;
 import android.content.res.ColorStateList;
-import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -14,14 +13,14 @@ import android.support.v7.widget.AppCompatButton;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
-
 import com.mercadolibre.android.ui.R;
 import com.mercadolibre.android.ui.font.Font;
 import com.mercadolibre.android.ui.font.TypefaceHelper;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import static com.mercadolibre.android.ui.widgets.MeliButton.Size.LARGE;
+import static com.mercadolibre.android.ui.widgets.MeliButton.Size.SMALL;
 import static com.mercadolibre.android.ui.widgets.MeliButton.State.DISABLED;
 import static com.mercadolibre.android.ui.widgets.MeliButton.State.NORMAL;
 import static com.mercadolibre.android.ui.widgets.MeliButton.Type.ACTION_PRIMARY;
@@ -45,6 +44,11 @@ public final class MeliButton extends AppCompatButton {
      */
     @Type
     private int type;
+    /**
+     * The type of button (Large, Small)
+     */
+    @Size
+    private int size;
 
     /**
      * Default constructor without attrs, defaults will be used: type=ActionPrimary state=Normal.
@@ -82,13 +86,14 @@ public final class MeliButton extends AppCompatButton {
     private void configureButton(@NonNull final Context context, @Nullable final AttributeSet attrs, int defStyleAttr) {
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MeliButton, defStyleAttr, 0);
         final int buttonType = a.getInt(R.styleable.MeliButton_type, ACTION_PRIMARY);
+        final int buttonSize = a.getInt(R.styleable.MeliButton_button_size, LARGE);
         final int buttonState = a.getInt(R.styleable.MeliButton_state, NORMAL);
 
         TypefaceHelper.setTypeface(this, Font.REGULAR);
         setGravity(Gravity.CENTER);
-        setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimensionPixelSize(R.dimen.ui_fontsize_medium));
 
         setType(buttonType);
+        setSize(buttonSize);
         setState(buttonState);
     }
 
@@ -129,12 +134,40 @@ public final class MeliButton extends AppCompatButton {
         }
     }
 
+    private void configureSize(@Size final int buttonSize) {
+        final int sizeDimen;
+        final int minHeightDimen;
+
+        switch (buttonSize) {
+            case SMALL:
+                sizeDimen = R.dimen.ui_fontsize_xsmall;
+                minHeightDimen = R.dimen.ui_small_button_height;
+                break;
+            case LARGE:
+            default:
+                sizeDimen = R.dimen.ui_fontsize_medium;
+                minHeightDimen = R.dimen.ui_button_height;
+        }
+        //setMinHeight(getResources().getDimensionPixelSize(minHeightDimen));
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimensionPixelSize(sizeDimen));
+    }
+
     /*
         This was modified to reach exactly 48dp in height.
      */
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
-        final int maxHeight = getResources().getDimensionPixelSize(R.dimen.ui_button_height);
+        final int heightDimen;
+        switch (size) {
+            case SMALL:
+                heightDimen = R.dimen.ui_small_button_height;
+                break;
+            case LARGE:
+            default:
+                heightDimen = R.dimen.ui_button_height;
+        }
+
+        final int maxHeight = getResources().getDimensionPixelSize(heightDimen);
         final int newHeightMeasureSpec = MeasureSpec.makeMeasureSpec(maxHeight, MeasureSpec.EXACTLY);
         super.onMeasure(widthMeasureSpec, newHeightMeasureSpec);
     }
@@ -180,6 +213,26 @@ public final class MeliButton extends AppCompatButton {
     }
 
     /**
+     * Gets the button size {@link #size}
+     *
+     * @return the button's size
+     */
+    @Type
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Sets the button size {@link #size}
+     *
+     * @param size Button.size
+     */
+    public void setSize(@Type final int size) {
+        this.size = size;
+        configureSize(size);
+    }
+
+    /**
      * Possible button types
      */
     @SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.CommentDefaultAccessModifier"})
@@ -189,6 +242,17 @@ public final class MeliButton extends AppCompatButton {
         int ACTION_PRIMARY = 0;
         int ACTION_SECONDARY = 1;
         int OPTION_PRIMARY = 2;
+    }
+
+    /**
+     * Possible button sizes
+     */
+    @SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.CommentDefaultAccessModifier"})
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({LARGE, SMALL})
+    public @interface Size {
+        int LARGE = 0;
+        int SMALL = 1;
     }
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
@@ -248,7 +248,6 @@ public final class MeliButton extends AppCompatButton {
     /**
      * Possible button sizes
      */
-    @SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.CommentDefaultAccessModifier"})
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({LARGE, SMALL})
     public @interface Size {

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliButton.java
@@ -153,8 +153,8 @@ public final class MeliButton extends AppCompatButton {
         setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(sizeDimen));
     }
 
-    /*
-        This was modified to reach exactly 48dp/36dp in height.
+    /**
+     *  This was modified to reach exactly the desired {@link Size}'s height.
      */
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
@@ -247,6 +247,11 @@ public final class MeliButton extends AppCompatButton {
 
     /**
      * Possible button sizes
+     *
+     * According to <a href="https://mercadolibre.github.io/frontend-andes/componente/button/?unit=ml#tipos">Andes doc: </a>
+     *
+     * Large size has a fixed height of 48dp.
+     * Small size has a fixed height of 36dp.
      */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({LARGE, SMALL})

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSnackbar.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliSnackbar.java
@@ -15,18 +15,11 @@ import android.util.TypedValue;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-
 import com.mercadolibre.android.ui.R;
 import com.mercadolibre.android.ui.font.Font;
 import com.mercadolibre.android.ui.font.TypefaceHelper;
-
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-
-import static com.mercadolibre.android.ui.widgets.MeliSnackbar.Type.ERROR;
-import static com.mercadolibre.android.ui.widgets.MeliSnackbar.Type.MESSAGE;
-import static com.mercadolibre.android.ui.widgets.MeliSnackbar.Type.SUCCESS;
 
 /**
  * Snackbar wrapper that allows extra customization.

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -235,6 +235,10 @@
             <enum name="actionSecondary" value="1"/>
             <enum name="optionPrimary" value="2"/>
         </attr>
+        <attr name="button_size" format="enum">
+            <enum name="large" value="0"/>
+            <enum name="small" value="1"/>
+        </attr>
         <attr name="state" format="enum">
             <enum name="normal" value="0"/>
             <enum name="disable" value="1"/>

--- a/ui/src/main/res/values/dimens.xml
+++ b/ui/src/main/res/values/dimens.xml
@@ -21,6 +21,7 @@
 
     <!-- Buttons -->
     <dimen name="ui_button_height">48dp</dimen>
+    <dimen name="ui_small_button_height">36dp</dimen>
     <dimen name="ui_button_corner_radius">4dp</dimen>
     <dimen name="ui_button_padding">8dp</dimen>
     <dimen name="ui_button_checkbox_margin">16dp</dimen>

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliButtonTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliButtonTest.java
@@ -93,7 +93,7 @@ public class MeliButtonTest {
     }
 
     @Test
-    public void testSizeLarge() {
+    public void testCorrectValuesInButtonWithSizeLarge() {
         button.setSize(MeliButton.Size.LARGE);
         final float textSize = 18F;
         Assert.assertEquals(textSize, button.getTextSize(), 0);
@@ -101,7 +101,7 @@ public class MeliButtonTest {
     }
 
     @Test
-    public void testSizeSmall() {
+    public void testCorrectValuesInButtonWithSizeSmall() {
         button.setSize(MeliButton.Size.SMALL);
         final float textSize = 14F;
         Assert.assertEquals(textSize, button.getTextSize(), 0);

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliButtonTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/MeliButtonTest.java
@@ -91,5 +91,21 @@ public class MeliButtonTest {
                 getColorForState(states, defTextColor));
         Assert.assertEquals(MeliButton.Type.OPTION_PRIMARY, button.getType());
     }
+
+    @Test
+    public void testSizeLarge() {
+        button.setSize(MeliButton.Size.LARGE);
+        final float textSize = 18F;
+        Assert.assertEquals(textSize, button.getTextSize(), 0);
+        Assert.assertEquals(MeliButton.Size.LARGE, button.getSize());
+    }
+
+    @Test
+    public void testSizeSmall() {
+        button.setSize(MeliButton.Size.SMALL);
+        final float textSize = 14F;
+        Assert.assertEquals(textSize, button.getTextSize(), 0);
+        Assert.assertEquals(MeliButton.Size.SMALL, button.getSize());
+    }
 }
 


### PR DESCRIPTION
## Descripción

Agregamos un nuevo _attribute_ para `MeliButton`, `button_size` el cual aplica unas pequeñas modificaciones de _textSize_ y _minHeight_.

## ¿Por qué necesitamos este cambio?

Necesitamos este cambio ya que en PDP, tenemos [este caso](https://app.zeplin.io/project/5c48691f01c526377487f2e5/screen/5d727afa50db6d7380b12cb7) donde se nos pide un boton de tipo `Small`.

Dejo [link de referencia](https://mercadolibre.github.io/frontend-andes/componente/button/?unit=ml#tipos) a la **doc actual** de Andes, de donde extraje los valores.

## Screenshots

<image src="https://user-images.githubusercontent.com/10566629/64713380-22c30d00-d493-11e9-8067-c5a28fab7d50.png" height=550 />
