### PR TITLE
[Feat] bye font callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-#8.0.0
+# v8.0.0
 ## Cambiado
 - TypefaceHelper.getTypeface se depreca por TypefaceHelper.getFontTypeface
 - Se cambia firma de TypefaceHelper.getTypeface para que retorne un Typeface en vez de responde mediante un ResourcesCompat.FontCallback
 
-#7.1.0
+# v7.1.0
 ## Agregado
 - Se agrega soporte al caso de `Small` para MeliButton, segun Andes.
 
-#7.0.0
+# v7.0.0
 ## Arreglado
 - Se vuelve a agregar el attr autostart en MeliSpinner por retro compatibilidad
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#8.0.0
+## Cambiado
+- TypefaceHelper.getTypeface se depreca por TypefaceHelper.getFontTypeface
+- Se cambia firma de TypefaceHelper.getTypeface para que retorne un Typeface en vez de responde mediante un ResourcesCompat.FontCallback
+
 #7.1.0
 ## Agregado
 - Se agrega soporte al caso de `Small` para MeliButton, segun Andes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=7.1.0
+libraryVersion=8.0.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
@@ -9,6 +9,9 @@ import android.widget.TextView;
 
 import uk.co.chrisjenx.calligraphy.TypefaceUtils;
 
+/**
+ * This TypefaceSetter implements Calligraphy library.
+ */
 public class CalligraphyTypefaceSetter implements TypefaceHelper.TypefaceSetter {
     @Override
     public <T extends TextView> void setTypeface(@NonNull final T view, @NonNull final Font font) {

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
@@ -1,0 +1,38 @@
+package com.mercadolibre.android.ui.font;
+
+import android.content.Context;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.support.annotation.NonNull;
+import android.widget.Switch;
+import android.widget.TextView;
+
+import uk.co.chrisjenx.calligraphy.TypefaceUtils;
+
+public class CalligraphyTypefaceSetter implements TypefaceHelper.TypefaceSetter {
+    @Override
+    public <T extends TextView> void setTypeface(@NonNull final T view, @NonNull final Font font) {
+        final Typeface typeface = createTypeface(view.getContext(), font);
+        view.setTypeface(typeface);
+
+        if (view instanceof Switch) {
+            ((Switch) view).setSwitchTypeface(typeface);
+        }
+    }
+
+    @Override
+    public void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font) {
+        final Typeface typeface = createTypeface(context, font);
+        paint.setTypeface(typeface);
+    }
+
+    @Override
+    public Typeface getTypeface(@NonNull Context context, @NonNull Font font) {
+        return createTypeface(context, font);
+    }
+
+    private Typeface createTypeface(@NonNull Context context, @NonNull Font font) {
+        return TypefaceUtils.load(context.getAssets(), font.getFontPath());
+    }
+
+}

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
-import android.support.v4.content.res.ResourcesCompat;
 import android.widget.TextView;
 
 /**
@@ -51,23 +50,6 @@ public final class TypefaceHelper {
      */
     public static void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font) {
         typefaceSetter.setTypeface(context, paint, font);
-    }
-
-    /**
-     * Get a typeface associated to the font passed. The typeface will be sent through the
-     * font callback passed as param
-     *
-     * @param context to use
-     * @param font to retrieve its typeface
-     * @param fontCallback to call when the typeface is retrieved
-     *
-     * @deprecated use geyFontTypeface instead
-     */
-    @SuppressWarnings("PMD.LinguisticNaming")
-    @Deprecated
-    public static void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
-        Typeface typeface = TypefaceHelper.geyFontTypeface(context, font);
-        fontCallback.onFontRetrieved(typeface);
     }
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -66,7 +66,7 @@ public final class TypefaceHelper {
     @SuppressWarnings("PMD.LinguisticNaming")
     @Deprecated
     public static void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
-        Typeface typeface = typefaceSetter.getTypeface(context, font);
+        Typeface typeface = TypefaceHelper.geyFontTypeface(context, font);
         fontCallback.onFontRetrieved(typeface);
     }
 

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -4,13 +4,8 @@ import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v4.content.res.ResourcesCompat;
-import android.support.v4.provider.FontsContractCompat;
-import android.widget.Switch;
 import android.widget.TextView;
-
-import uk.co.chrisjenx.calligraphy.TypefaceUtils;
 
 /**
  * This class is used as a wrapper for our custom font.
@@ -22,43 +17,7 @@ public final class TypefaceHelper {
     private static TypefaceSetter typefaceSetter;
 
     static {
-        typefaceSetter = new TypefaceSetter() {
-            @Override
-            public <T extends TextView> void setTypeface(@NonNull final T view, @NonNull final Font font) {
-                final Typeface typeface = createTypeface(view.getContext(), font);
-                view.setTypeface(typeface);
-
-                if (view instanceof Switch) {
-                    ((Switch) view).setSwitchTypeface(typeface);
-                }
-            }
-
-            @Override
-            public void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font) {
-                final Typeface typeface = createTypeface(context, font);
-                paint.setTypeface(typeface);
-            }
-
-            @Override
-            @SuppressWarnings("PMD.LinguisticNaming")
-            public void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
-                final Typeface typeface = createTypeface(context, font);
-
-                if (typeface == null) {
-                    fontCallback.onFontRetrievalFailed(FontsContractCompat.FontRequestCallback.FAIL_REASON_FONT_NOT_FOUND);
-                } else {
-                    fontCallback.onFontRetrieved(typeface);
-                }
-            }
-
-            @Nullable
-            private Typeface createTypeface(@NonNull Context context, @Nullable Font font) {
-                if (font == null) {
-                    return null;
-                }
-                return TypefaceUtils.load(context.getAssets(), font.getFontPath());
-            }
-        };
+        typefaceSetter = new CalligraphyTypefaceSetter();
     }
 
     private TypefaceHelper() {
@@ -101,10 +60,25 @@ public final class TypefaceHelper {
      * @param context to use
      * @param font to retrieve its typeface
      * @param fontCallback to call when the typeface is retrieved
+     *
+     * @deprecated use geyFontTypeface instead
      */
     @SuppressWarnings("PMD.LinguisticNaming")
+    @Deprecated
     public static void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
-        typefaceSetter.getTypeface(context, font, fontCallback);
+        Typeface typeface = typefaceSetter.getTypeface(context, font);
+        fontCallback.onFontRetrieved(typeface);
+    }
+
+    /**
+     * Get a tyoeface associated to the font passed.
+
+     * @param context to use
+     * @param font to use
+     * @return associated typeface
+     */
+    public static Typeface geyFontTypeface(@NonNull final Context context, @NonNull Font font) {
+        return typefaceSetter.getTypeface(context, font);
     }
 
     /**
@@ -129,16 +103,11 @@ public final class TypefaceHelper {
         void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font);
 
         /**
-         * Get a typeface associated to the font passed. The typeface will be sent through the
-         * font callback passed as param
-         *
+         * Return the typeface associated with the font
          * @param context to use
-         * @param font to retrieve its typeface
-         * @param fontCallback to call when the typeface is retrieved
+         * @param font to find the typeface
+         * @return typeface associated
          */
-        @SuppressWarnings("PMD.LinguisticNaming")
-        void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback);
-
+        Typeface getTypeface(@NonNull Context context, @NonNull final Font font);
     }
-
 }

--- a/ui/src/test/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetterTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetterTest.java
@@ -1,0 +1,102 @@
+package com.mercadolibre.android.ui.font;
+
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.RadioButton;
+import android.widget.Switch;
+import android.widget.TextView;
+import android.widget.ToggleButton;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.EnumMap;
+
+import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
+import uk.co.chrisjenx.calligraphy.TypefaceUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+public class CalligraphyTypefaceSetterTest {
+
+    private CalligraphyTypefaceSetter calligraphyTypefaceSetter = new CalligraphyTypefaceSetter();
+
+    @Before
+    public void setUp() {
+        final EnumMap<Font, String> fontsHashMap = new EnumMap<>(Font.class);
+        fontsHashMap.put(Font.BOLD,"Roboto-Bold.ttf");
+        fontsHashMap.put(Font.BLACK,"Roboto-Black.ttf");
+        fontsHashMap.put(Font.EXTRA_BOLD,"RobotoCondensed-Bold.ttf");
+        fontsHashMap.put(Font.LIGHT,"Roboto-Light.ttf");
+        fontsHashMap.put(Font.MEDIUM,"Roboto-Medium.ttf");
+        fontsHashMap.put(Font.REGULAR,"Roboto-Regular.ttf");
+        fontsHashMap.put(Font.SEMI_BOLD,"Roboto-Medium.ttf");
+        fontsHashMap.put(Font.THIN,"Roboto-Thin.ttf");
+
+        Font.FontConfig.setFonts(fontsHashMap);
+        CalligraphyConfig.initDefault(new CalligraphyConfig.Builder().build());
+    }
+
+    @Test
+    public void testSetTypeface_withTextView() {
+        verifyFontCanBeSet(new TextView(RuntimeEnvironment.application), Font.BLACK);
+    }
+
+    @Test
+    public void testSetTypeface_withEditText() {
+        verifyFontCanBeSet(new EditText(RuntimeEnvironment.application), Font.LIGHT);
+    }
+
+    @Test
+    public void testSetTypeface_withButton() {
+        verifyFontCanBeSet(new Button(RuntimeEnvironment.application), Font.REGULAR);
+    }
+
+    @Test
+    public void testSetTypeface_withToggleButton() {
+        verifyFontCanBeSet(new ToggleButton(RuntimeEnvironment.application), Font.BOLD);
+    }
+
+    @Test
+    public void testSetTypeface_withSwitch() {
+        verifyFontCanBeSet(new Switch(RuntimeEnvironment.application), Font.EXTRA_BOLD);
+    }
+
+    @Test
+    public void testSetTypeface_withCheckBox() {
+        verifyFontCanBeSet(new CheckBox(RuntimeEnvironment.application), Font.SEMI_BOLD);
+    }
+
+    @Test
+    public void testSetTypeface_withRadioButton() {
+        verifyFontCanBeSet(new RadioButton(RuntimeEnvironment.application), Font.LIGHT);
+    }
+
+    @Test
+    public void testSetTypeface_withPaint() {
+        final Paint paint = new Paint();
+
+        assertNull(paint.getTypeface());
+        TypefaceHelper.setTypeface(RuntimeEnvironment.application, paint, Font.LIGHT);
+
+        Typeface expected = TypefaceUtils.load(RuntimeEnvironment.application.getAssets(), Font.LIGHT.getFontPath());
+        assertEquals(expected, paint.getTypeface());
+    }
+
+    private <T extends TextView> void verifyFontCanBeSet(final T view, final Font font) {
+        calligraphyTypefaceSetter.setTypeface(view, font);
+        final Typeface expected = TypefaceUtils.load(RuntimeEnvironment.application.getAssets(), font.getFontPath());
+        assertEquals(expected, view.getTypeface());
+    }
+}

--- a/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
@@ -1,100 +1,71 @@
 package com.mercadolibre.android.ui.font;
 
-import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Build;
-import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.EditText;
-import android.widget.RadioButton;
-import android.widget.Switch;
-import android.widget.TextView;
-import android.widget.ToggleButton;
+import android.support.v4.content.res.ResourcesCompat;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import java.util.EnumMap;
-
-import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
-import uk.co.chrisjenx.calligraphy.TypefaceUtils;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
 public class TypefaceHelperTest {
 
-    @Before
-    public void setUp() {
-        final EnumMap<Font, String> fontsHashMap = new EnumMap<>(Font.class);
-        fontsHashMap.put(Font.BOLD,"Roboto-Bold.ttf");
-        fontsHashMap.put(Font.BLACK,"Roboto-Black.ttf");
-        fontsHashMap.put(Font.EXTRA_BOLD,"RobotoCondensed-Bold.ttf");
-        fontsHashMap.put(Font.LIGHT,"Roboto-Light.ttf");
-        fontsHashMap.put(Font.MEDIUM,"Roboto-Medium.ttf");
-        fontsHashMap.put(Font.REGULAR,"Roboto-Regular.ttf");
-        fontsHashMap.put(Font.SEMI_BOLD,"Roboto-Medium.ttf");
-        fontsHashMap.put(Font.THIN,"Roboto-Thin.ttf");
+    private TypefaceHelper.TypefaceSetter typefaceSetter = mock(TypefaceHelper.TypefaceSetter.class);
+    private Typeface expectedTypeface = mock(Typeface.class);
+    private ResourcesCompat.FontCallback fontCallback = mock(ResourcesCompat.FontCallback.class);
+    private Typeface typeface;
 
-        Font.FontConfig.setFonts(fontsHashMap);
-        CalligraphyConfig.initDefault(new CalligraphyConfig.Builder().build());
+    @Test
+    public void testGetFontTypeface() {
+        givenATypeface(Font.LIGHT);
+        givenACustomTypefaceSetter();
+
+        whenGettingTypefaceSync(Font.LIGHT);
+
+        thenTypefaceIsReturned();
     }
 
     @Test
-    public void testSetTypeface_withTextView() {
-        verifyFontCanBeSet(new TextView(RuntimeEnvironment.application), Font.BLACK);
+    public void testGetTypefaceAsync() {
+        givenATypeface(Font.BLACK);
+        givenACustomTypefaceSetter();
+
+        whenGettingTypefaceAsync(Font.BLACK);
+
+        thenTypefaceIsReturnedAsync(fontCallback);
     }
 
-    @Test
-    public void testSetTypeface_withEditText() {
-        verifyFontCanBeSet(new EditText(RuntimeEnvironment.application), Font.LIGHT);
+    private void givenACustomTypefaceSetter() {
+        TypefaceHelper.attachTypefaceSetter(typefaceSetter);
     }
 
-    @Test
-    public void testSetTypeface_withButton() {
-        verifyFontCanBeSet(new Button(RuntimeEnvironment.application), Font.REGULAR);
+    private void whenGettingTypefaceAsync(Font font) {
+        TypefaceHelper.getTypeface(RuntimeEnvironment.application, font, fontCallback);
     }
 
-    @Test
-    public void testSetTypeface_withToggleButton() {
-        verifyFontCanBeSet(new ToggleButton(RuntimeEnvironment.application), Font.BOLD);
+    private void whenGettingTypefaceSync(Font font) {
+        typeface = TypefaceHelper.geyFontTypeface(RuntimeEnvironment.application, font);
     }
 
-    @Test
-    public void testSetTypeface_withSwitch() {
-        verifyFontCanBeSet(new Switch(RuntimeEnvironment.application), Font.EXTRA_BOLD);
+    private void thenTypefaceIsReturnedAsync(ResourcesCompat.FontCallback fontCallback) {
+        verify(fontCallback, only()).onFontRetrieved(expectedTypeface);
     }
 
-    @Test
-    public void testSetTypeface_withCheckBox() {
-        verifyFontCanBeSet(new CheckBox(RuntimeEnvironment.application), Font.SEMI_BOLD);
+    private void thenTypefaceIsReturned() {
+        assertEquals(expectedTypeface, typeface);
     }
 
-    @Test
-    public void testSetTypeface_withRadioButton() {
-        verifyFontCanBeSet(new RadioButton(RuntimeEnvironment.application), Font.LIGHT);
-    }
-
-    @Test
-    public void testSetTypeface_withPaint() {
-        final Paint paint = new Paint();
-
-        assertNull(paint.getTypeface());
-        TypefaceHelper.setTypeface(RuntimeEnvironment.application, paint, Font.LIGHT);
-
-        Typeface expected = TypefaceUtils.load(RuntimeEnvironment.application.getAssets(), Font.LIGHT.getFontPath());
-        assertEquals(expected, paint.getTypeface());
-    }
-
-    private <T extends TextView> void verifyFontCanBeSet(final T view, final Font font) {
-        TypefaceHelper.setTypeface(view, font);
-        final Typeface expected = TypefaceUtils.load(RuntimeEnvironment.application.getAssets(), font.getFontPath());
-        assertEquals(expected, view.getTypeface());
+    private void givenATypeface(Font font) {
+        when(typefaceSetter.getTypeface(RuntimeEnvironment.application, font)).thenReturn(expectedTypeface);
     }
 }

--- a/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
@@ -2,7 +2,6 @@ package com.mercadolibre.android.ui.font;
 
 import android.graphics.Typeface;
 import android.os.Build;
-import android.support.v4.content.res.ResourcesCompat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,8 +11,6 @@ import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
@@ -22,7 +19,6 @@ public class TypefaceHelperTest {
 
     private TypefaceHelper.TypefaceSetter typefaceSetter = mock(TypefaceHelper.TypefaceSetter.class);
     private Typeface expectedTypeface = mock(Typeface.class);
-    private ResourcesCompat.FontCallback fontCallback = mock(ResourcesCompat.FontCallback.class);
     private Typeface typeface;
 
     @Test
@@ -30,35 +26,18 @@ public class TypefaceHelperTest {
         givenATypeface(Font.LIGHT);
         givenACustomTypefaceSetter();
 
-        whenGettingTypefaceSync(Font.LIGHT);
+        whenGettingTypeface(Font.LIGHT);
 
         thenTypefaceIsReturned();
-    }
-
-    @Test
-    public void testGetTypefaceAsync() {
-        givenATypeface(Font.BLACK);
-        givenACustomTypefaceSetter();
-
-        whenGettingTypefaceAsync(Font.BLACK);
-
-        thenTypefaceIsReturnedAsync(fontCallback);
     }
 
     private void givenACustomTypefaceSetter() {
         TypefaceHelper.attachTypefaceSetter(typefaceSetter);
     }
 
-    private void whenGettingTypefaceAsync(Font font) {
-        TypefaceHelper.getTypeface(RuntimeEnvironment.application, font, fontCallback);
-    }
 
-    private void whenGettingTypefaceSync(Font font) {
+    private void whenGettingTypeface(Font font) {
         typeface = TypefaceHelper.geyFontTypeface(RuntimeEnvironment.application, font);
-    }
-
-    private void thenTypefaceIsReturnedAsync(ResourcesCompat.FontCallback fontCallback) {
-        verify(fontCallback, only()).onFontRetrieved(expectedTypeface);
     }
 
     private void thenTypefaceIsReturned() {


### PR DESCRIPTION
## Descripción
- TypefaceHelper.getTypeface se depreca por TypefaceHelper.getFontTypeface
- Se cambia firma de TypefaceHelper.getTypeface para que retorne un Typeface en vez de responde mediante un ResourcesCompat.FontCallback

## ¿Por qué necesitamos este cambio?
- Es un primer paso para eliminar Calligraphy/Fontela dado que otros fends puden dejar de depender de un pedido "async" de una font. Cosa que los llevaba a usar Calligraphy por izquierda.