### PR TITLE
[Feat] GetTypeface puede devolver null, se agrega annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.1.0
+## Agregado
+- Se agregan algunas annotations @Nulleable dado que la typeface puede resultar null en el caso de Calligraphy. Una vez que eliminemos la lib podemos depender de una typeface no nulleable.
+
 # v8.0.0
 ## Cambiado
 - TypefaceHelper.getTypeface se depreca por TypefaceHelper.getFontTypeface

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=8.0.0
+libraryVersion=8.1.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/CalligraphyTypefaceSetter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -30,10 +31,12 @@ public class CalligraphyTypefaceSetter implements TypefaceHelper.TypefaceSetter 
     }
 
     @Override
+    @Nullable
     public Typeface getTypeface(@NonNull Context context, @NonNull Font font) {
         return createTypeface(context, font);
     }
 
+    @Nullable
     private Typeface createTypeface(@NonNull Context context, @NonNull Font font) {
         return TypefaceUtils.load(context.getAssets(), font.getFontPath());
     }

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.widget.TextView;
 
 /**
@@ -59,6 +60,7 @@ public final class TypefaceHelper {
      * @param font to use
      * @return associated typeface
      */
+    @Nullable
     public static Typeface geyFontTypeface(@NonNull final Context context, @NonNull Font font) {
         return typefaceSetter.getTypeface(context, font);
     }
@@ -90,6 +92,7 @@ public final class TypefaceHelper {
          * @param font to find the typeface
          * @return typeface associated
          */
+        @Nullable
         Typeface getTypeface(@NonNull Context context, @NonNull final Font font);
     }
 }


### PR DESCRIPTION
## Descripción
Se agregan algunas annotations @Nulleable dado que la typeface puede resultar null en el caso de Calligraphy. Una vez que eliminemos la lib podemos depender de una typeface no nulleable.

## ¿Por qué necesitamos este cambio?
Es necesario para que Kotlin entienda que el metodo devuelve Typeface?