### PR TITLE
[Feat] Se agrega TypefaceSpanCompat para remplazar CalligraphyTypefaceSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v8.1.0
 ## Agregado
 - Se agregan algunas annotations @Nulleable dado que la typeface puede resultar null en el caso de Calligraphy. Una vez que eliminemos la lib podemos depender de una typeface no nulleable.
+- Se agrega TypefaceSpanCompat para remplazar CalligraphyTypefaceSpan
 
 # v8.0.0
 ## Cambiado

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
@@ -1,0 +1,50 @@
+package com.mercadolibre.android.ui.font;
+
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.support.annotation.NonNull;
+import android.text.TextPaint;
+import android.text.style.TypefaceSpan;
+
+/**
+ * This class replace the CalligraphyTypefaceSpan from Calligraphy
+ * The motivation is to no depend on a library implementation
+ */
+public class TypefaceSpanCompat extends TypefaceSpan {
+
+    private final Typeface typeface;
+
+    TypefaceSpanCompat(final Typeface typeface) {
+        super("");
+        if (typeface == null) {
+            throw new IllegalArgumentException("typeface is null");
+        }
+        this.typeface = typeface;
+    }
+
+    @Override
+    public void updateDrawState(@NonNull final TextPaint drawState) {
+        apply(drawState);
+    }
+
+    @Override
+    public void updateMeasureState(@NonNull final TextPaint paint) {
+        apply(paint);
+    }
+
+    private void apply(final Paint paint) {
+        final Typeface oldTypeface = paint.getTypeface();
+        final int oldStyle = oldTypeface != null ? oldTypeface.getStyle() : 0;
+        final int fakeStyle = oldStyle & ~typeface.getStyle();
+
+        if ((fakeStyle & Typeface.BOLD) != 0) {
+            paint.setFakeBoldText(true);
+        }
+
+        if ((fakeStyle & Typeface.ITALIC) != 0) {
+            paint.setTextSkewX(-0.25f);
+        }
+
+        paint.setTypeface(typeface);
+    }
+}

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
@@ -8,7 +8,7 @@ import android.text.TextPaint;
 import android.text.style.TypefaceSpan;
 
 /**
- * This class replace the CalligraphyTypefaceSpan from Calligraphy
+ * This class replace the <a href="https://github.com/chrisjenx/Calligraphy/blob/master/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java">CalligraphyTypefaceSpan</a> from <a href="https://github.com/chrisjenx/Calligraphy">Calligraphy</a>
  * The motivation is to no depend on a library implementation
  */
 public class TypefaceSpanCompat extends TypefaceSpan {

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
@@ -3,6 +3,7 @@ package com.mercadolibre.android.ui.font;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextPaint;
 import android.text.style.TypefaceSpan;
 
@@ -12,17 +13,17 @@ import android.text.style.TypefaceSpan;
  */
 public class TypefaceSpanCompat extends TypefaceSpan {
 
+    private final static float SKEW_X = -0.25f;
+
+    @NonNull
     private final Typeface typeface;
 
     /**
      * Default constructor
      * @param typeface typeface
      */
-    /* default */ TypefaceSpanCompat(final Typeface typeface) {
+    /* default */ TypefaceSpanCompat(@NonNull final Typeface typeface) {
         super("");
-        if (typeface == null) {
-            throw new IllegalArgumentException("typeface is null");
-        }
         this.typeface = typeface;
     }
 
@@ -36,7 +37,7 @@ public class TypefaceSpanCompat extends TypefaceSpan {
         apply(paint);
     }
 
-    private void apply(final Paint paint) {
+    private void apply(@NonNull final Paint paint) {
         final Typeface oldTypeface = paint.getTypeface();
         final int oldStyle = getOldStyle(oldTypeface);
         final int fakeStyle = oldStyle & ~typeface.getStyle();
@@ -46,13 +47,13 @@ public class TypefaceSpanCompat extends TypefaceSpan {
         }
 
         if ((fakeStyle & Typeface.ITALIC) != 0) {
-            paint.setTextSkewX(-0.25f);
+            paint.setTextSkewX(SKEW_X);
         }
 
         paint.setTypeface(typeface);
     }
 
-    private int getOldStyle(Typeface oldTypeface) {
+    private int getOldStyle(@Nullable Typeface oldTypeface) {
         if (oldTypeface == null) {
             return 0;
         }

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanCompat.java
@@ -14,7 +14,11 @@ public class TypefaceSpanCompat extends TypefaceSpan {
 
     private final Typeface typeface;
 
-    TypefaceSpanCompat(final Typeface typeface) {
+    /**
+     * Default constructor
+     * @param typeface typeface
+     */
+    /* default */ TypefaceSpanCompat(final Typeface typeface) {
         super("");
         if (typeface == null) {
             throw new IllegalArgumentException("typeface is null");
@@ -34,7 +38,7 @@ public class TypefaceSpanCompat extends TypefaceSpan {
 
     private void apply(final Paint paint) {
         final Typeface oldTypeface = paint.getTypeface();
-        final int oldStyle = oldTypeface != null ? oldTypeface.getStyle() : 0;
+        final int oldStyle = getOldStyle(oldTypeface);
         final int fakeStyle = oldStyle & ~typeface.getStyle();
 
         if ((fakeStyle & Typeface.BOLD) != 0) {
@@ -46,5 +50,12 @@ public class TypefaceSpanCompat extends TypefaceSpan {
         }
 
         paint.setTypeface(typeface);
+    }
+
+    private int getOldStyle(Typeface oldTypeface) {
+        if (oldTypeface == null) {
+            return 0;
+        }
+        return oldTypeface.getStyle();
     }
 }

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
@@ -2,10 +2,15 @@ package com.mercadolibre.android.ui.font;
 
 import android.graphics.Typeface;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.text.style.TypefaceSpan;
 
+/**
+ * This class wrap the TypefaceSpan creation to split according to the Android API version
+ */
+@SuppressWarnings("unused")
 public class TypefaceSpanFactory {
-    public TypefaceSpan create(Typeface typeface) {
+    public TypefaceSpan create(@NonNull Typeface typeface) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             return new TypefaceSpan(typeface);
         }

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
@@ -1,0 +1,14 @@
+package com.mercadolibre.android.ui.font;
+
+import android.graphics.Typeface;
+import android.os.Build;
+import android.text.style.TypefaceSpan;
+
+public class TypefaceSpanFactory {
+    public TypefaceSpan create(Typeface typeface) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return new TypefaceSpan(typeface);
+        }
+        return new TypefaceSpanCompat(typeface);
+    }
+}

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceSpanFactory.java
@@ -10,6 +10,7 @@ import android.text.style.TypefaceSpan;
  */
 @SuppressWarnings("unused")
 public class TypefaceSpanFactory {
+    @NonNull
     public TypefaceSpan create(@NonNull Typeface typeface) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             return new TypefaceSpan(typeface);


### PR DESCRIPTION
## Descripción
La idea es dejar de depender de CalligraphyTypefaceSpan.
TypefaceSpanCompat es una copia basicamente con la particularidad que hereda de TypefaceSpan para mantener la compatbilidad.