### PR TITLE
[Revert] Se vuelve a agregar metodo TypefaceHelper.getTypeface()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.2.0
+## Agregado
+- Se vuelve a agregar metodo TypefaceHelper.getTypeface(context, font, callback) por compatabilidad. Se depreca su uso por TypefaceHelper.getFontTypeface(context, font)
+
 # v8.1.0
 ## Agregado
 - Se agregan algunas annotations @Nulleable dado que la typeface puede resultar null en el caso de Calligraphy. Una vez que eliminemos la lib podemos depender de una typeface no nulleable.

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=8.1.0
+libraryVersion=8.2.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -64,7 +64,7 @@ public final class TypefaceHelper {
      * @param font to retrieve its typeface
      * @param fontCallback to call when the typeface is retrieved
      *
-     * @deprecated use geyFontTypeface instead
+     * @deprecated use TypefaceHelper{@link #geyFontTypeface(Context, Font)} instead
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     @Deprecated
@@ -78,7 +78,7 @@ public final class TypefaceHelper {
     }
 
     /**
-     * Get a tyoeface associated to the font passed.
+     * Get a typeface associated to the font passed.
 
      * @param context to use
      * @param font to use

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -5,7 +5,10 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.res.ResourcesCompat;
 import android.widget.TextView;
+
+import static android.support.v4.provider.FontsContractCompat.FontRequestCallback.FAIL_REASON_FONT_NOT_FOUND;
 
 /**
  * This class is used as a wrapper for our custom font.
@@ -51,6 +54,27 @@ public final class TypefaceHelper {
      */
     public static void setTypeface(@NonNull final Context context, @NonNull final Paint paint, @NonNull final Font font) {
         typefaceSetter.setTypeface(context, paint, font);
+    }
+
+    /**
+     * Get a typeface associated to the font passed. The typeface will be sent through the
+     * font callback passed as param
+     *
+     * @param context to use
+     * @param font to retrieve its typeface
+     * @param fontCallback to call when the typeface is retrieved
+     *
+     * @deprecated use geyFontTypeface instead
+     */
+    @SuppressWarnings("PMD.LinguisticNaming")
+    @Deprecated
+    public static void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
+        Typeface typeface = TypefaceHelper.geyFontTypeface(context, font);
+        if (typeface == null) {
+            fontCallback.onFontRetrievalFailed(FAIL_REASON_FONT_NOT_FOUND);
+        } else {
+            fontCallback.onFontRetrieved(typeface);
+        }
     }
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/font/TypefaceHelper.java
@@ -64,12 +64,12 @@ public final class TypefaceHelper {
      * @param font to retrieve its typeface
      * @param fontCallback to call when the typeface is retrieved
      *
-     * @deprecated use TypefaceHelper{@link #geyFontTypeface(Context, Font)} instead
+     * @deprecated use TypefaceHelper{@link #getFontTypeface(Context, Font)} instead
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     @Deprecated
     public static void getTypeface(@NonNull final Context context, @NonNull final Font font, @NonNull final ResourcesCompat.FontCallback fontCallback) {
-        Typeface typeface = TypefaceHelper.geyFontTypeface(context, font);
+        Typeface typeface = TypefaceHelper.getFontTypeface(context, font);
         if (typeface == null) {
             fontCallback.onFontRetrievalFailed(FAIL_REASON_FONT_NOT_FOUND);
         } else {
@@ -85,7 +85,7 @@ public final class TypefaceHelper {
      * @return associated typeface
      */
     @Nullable
-    public static Typeface geyFontTypeface(@NonNull final Context context, @NonNull Font font) {
+    public static Typeface getFontTypeface(@NonNull final Context context, @NonNull Font font) {
         return typefaceSetter.getTypeface(context, font);
     }
 

--- a/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
@@ -70,7 +70,7 @@ public class TypefaceHelperTest {
     }
 
     private void whenGettingTypeface(Font font) {
-        typeface = TypefaceHelper.geyFontTypeface(RuntimeEnvironment.application, font);
+        typeface = TypefaceHelper.getFontTypeface(RuntimeEnvironment.application, font);
     }
 
     private void thenTypefaceIsReturnedAsync() {

--- a/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/font/TypefaceHelperTest.java
@@ -2,6 +2,7 @@ package com.mercadolibre.android.ui.font;
 
 import android.graphics.Typeface;
 import android.os.Build;
+import android.support.v4.content.res.ResourcesCompat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,8 +10,11 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import static android.support.v4.provider.FontsContractCompat.FontRequestCallback.FAIL_REASON_FONT_NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
@@ -19,10 +23,11 @@ public class TypefaceHelperTest {
 
     private TypefaceHelper.TypefaceSetter typefaceSetter = mock(TypefaceHelper.TypefaceSetter.class);
     private Typeface expectedTypeface = mock(Typeface.class);
+    private ResourcesCompat.FontCallback fontCallback = mock(ResourcesCompat.FontCallback.class);
     private Typeface typeface;
 
     @Test
-    public void testGetFontTypeface() {
+    public void getFontTypeface() {
         givenATypeface(Font.LIGHT);
         givenACustomTypefaceSetter();
 
@@ -31,20 +36,52 @@ public class TypefaceHelperTest {
         thenTypefaceIsReturned();
     }
 
+    @Test
+    public void getTypefaceAsync() {
+        givenATypeface(Font.BLACK);
+        givenACustomTypefaceSetter();
+
+        whenGettingTypefaceAsync(Font.BLACK);
+
+        thenTypefaceIsReturnedAsync();
+    }
+
+    @Test
+    public void getTypefaceAsyncNotFound() {
+        givenACustomTypefaceSetter();
+
+        whenGettingTypefaceAsync(Font.BLACK);
+
+        thenCallbackFailWithFontNotFoundReason();
+
+    }
+
+    private void givenATypeface(Font font) {
+        when(typefaceSetter.getTypeface(RuntimeEnvironment.application, font)).thenReturn(expectedTypeface);
+    }
+
+
     private void givenACustomTypefaceSetter() {
         TypefaceHelper.attachTypefaceSetter(typefaceSetter);
     }
 
+    private void whenGettingTypefaceAsync(Font font) {
+        TypefaceHelper.getTypeface(RuntimeEnvironment.application, font, fontCallback);
+    }
 
     private void whenGettingTypeface(Font font) {
         typeface = TypefaceHelper.geyFontTypeface(RuntimeEnvironment.application, font);
+    }
+
+    private void thenTypefaceIsReturnedAsync() {
+        verify(fontCallback, only()).onFontRetrieved(expectedTypeface);
     }
 
     private void thenTypefaceIsReturned() {
         assertEquals(expectedTypeface, typeface);
     }
 
-    private void givenATypeface(Font font) {
-        when(typefaceSetter.getTypeface(RuntimeEnvironment.application, font)).thenReturn(expectedTypeface);
+    private void thenCallbackFailWithFontNotFoundReason() {
+        verify(fontCallback, only()).onFontRetrievalFailed(FAIL_REASON_FONT_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Descripción
Se vuelve a agregar metodo TypefaceHelper.getTypeface(context, font, callback) por compatabilidad.

## ¿Por qué necesitamos este cambio?
Para que la migracion sea mas simple para libs que tienen otras apps como puntos de acceso.