### PR TITLE
Fix TextField helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.3.0
+## Cambiado
+- Se arregla el helper del TextField para que no se oculte al hacer setError(null). También para que no se oculte al escribir cuando fue seteado por código.
+
 # v8.2.0
 ## Agregado
 - Se vuelve a agregar metodo TypefaceHelper.getTypeface(context, font, callback) por compatabilidad. Se depreca su uso por TypefaceHelper.getFontTypeface(context, font)

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -221,10 +221,9 @@ public final class TextField extends LinearLayout {
         setHint(hint);
         setMaxLines(maxLines);
         setMaxCharacters(maxCharacters);
+        setHelper(helperText);
         setEnabled(enabled);
         setCharactersCountVisible(charactersCountVisible);
-
-        setHelper(helperText);
 
         input.addTextChangedListener(new TextWatcher() {
             @Override
@@ -239,13 +238,9 @@ public final class TextField extends LinearLayout {
 
             @Override
             public void afterTextChanged(final Editable s) {
-                if (hasHelper) {
-                    if (s.length() > 0 && isShowingError) {
-                        clearError();
-                        setHelper(helperText);
-                    }
-                } else {
-                    setError(null);
+                if (s.length() > 0 && isShowingError) {
+                    clearError();
+                    setHelper(helperText);
                 }
             }
         });
@@ -353,15 +348,18 @@ public final class TextField extends LinearLayout {
      * @param helpText the text
      */
     public void setHelper(@Nullable final String helpText) {
-        if (!enabled || TextUtils.isEmpty(helpText)) {
-            helper.setVisibility(GONE);
+        final boolean isEmpty = TextUtils.isEmpty(helpText);
+        helperText = helpText;
+        helper.setText(helperText);
+        hasHelper = !isEmpty;
+        if (!enabled || isEmpty) {
+            hideHelper();
             return;
         }
         ViewCompat.setPaddingRelative(helper, 0,
-                0, 0, input.getPaddingBottom());
+            0, 0, input.getPaddingBottom());
         changeErrorVisibility(false);
         helper.setGravity(textAlign);
-        helper.setText(helpText);
         helper.setVisibility(VISIBLE);
         isShowingHelper = true;
     }
@@ -399,26 +397,29 @@ public final class TextField extends LinearLayout {
         if (!enabled) {
             return;
         }
-        isShowingError = true;
-        if (isShowingHelper) {
-            helper.setVisibility(GONE);
-            isShowingHelper = false;
-        }
-        changeErrorVisibility(true);
+        boolean isEmpty = TextUtils.isEmpty(error);
+        changeErrorVisibility(!isEmpty);
+        if (isEmpty) {
+            setHelper(helperText);
+        } else {
+            isShowingError = true;
+            if (isShowingHelper) {
+                hideHelper();
+            }
 
-        container.setError(error);
-
-        final TextView errorView = (TextView) container
+            final TextView errorView = (TextView) container
                 .findViewById(android.support.design.R.id.textinput_error);
 
-        TypefaceHelper.setTypeface(errorView, Font.SEMI_BOLD);
-        final FrameLayout.LayoutParams errorViewParams =
+            TypefaceHelper.setTypeface(errorView, Font.SEMI_BOLD);
+            final FrameLayout.LayoutParams errorViewParams =
                 new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
-        errorViewParams.gravity = textAlign;
-        errorView.setGravity(textAlign);
-        errorView.setLayoutParams(errorViewParams);
+            errorViewParams.gravity = textAlign;
+            errorView.setGravity(textAlign);
+            errorView.setLayoutParams(errorViewParams);
+        }
 
-        container.setErrorEnabled(!TextUtils.isEmpty(error));
+        container.setError(error);
+        container.setErrorEnabled(!isEmpty);
     }
 
     /**
@@ -782,15 +783,22 @@ public final class TextField extends LinearLayout {
 
     private void applyStatus() {
         if (enabled) {
-            container.setFocusableInTouchMode(true);
+            input.setFocusableInTouchMode(true);
             container.setEnabled(true);
             setMaxCharacters(maxCharacters);
+            setHelper(helperText);
         } else {
-            container.setFocusableInTouchMode(false);
+            input.setFocusableInTouchMode(false);
             container.setEnabled(false);
             setCharactersCountVisible(false);
-            setError(null);
+            clearError();
+            hideHelper();
         }
+    }
+
+    private void hideHelper() {
+        helper.setVisibility(GONE);
+        isShowingHelper = false;
     }
 
     @Override

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -783,12 +783,12 @@ public final class TextField extends LinearLayout {
 
     private void applyStatus() {
         if (enabled) {
-            input.setFocusableInTouchMode(true);
+            container.setFocusableInTouchMode(true);
             container.setEnabled(true);
             setMaxCharacters(maxCharacters);
             setHelper(helperText);
         } else {
-            input.setFocusableInTouchMode(false);
+            container.setFocusableInTouchMode(false);
             container.setEnabled(false);
             setCharactersCountVisible(false);
             clearError();

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
@@ -402,7 +402,7 @@ public class TextFieldTest {
     public void testSetEnabled_withEnabledTrue_shouldChangeTheState() {
         textField.setEnabled(true);
 
-        assertTrue(container.isFocusableInTouchMode());
+        assertTrue(editText.isFocusableInTouchMode());
         assertTrue(container.isEnabled());
     }
 
@@ -410,7 +410,7 @@ public class TextFieldTest {
     public void testSetEnabled_withEnabledFalse_shouldChangeTheState() {
         textField.setEnabled(false);
 
-        assertFalse(container.isFocusableInTouchMode());
+        assertFalse(editText.isFocusableInTouchMode());
         assertFalse(container.isEnabled());
         assertFalse(container.isCounterEnabled());
     }

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
@@ -402,7 +402,7 @@ public class TextFieldTest {
     public void testSetEnabled_withEnabledTrue_shouldChangeTheState() {
         textField.setEnabled(true);
 
-        assertTrue(editText.isFocusableInTouchMode());
+        assertTrue(container.isFocusableInTouchMode());
         assertTrue(container.isEnabled());
     }
 
@@ -410,7 +410,7 @@ public class TextFieldTest {
     public void testSetEnabled_withEnabledFalse_shouldChangeTheState() {
         textField.setEnabled(false);
 
-        assertFalse(editText.isFocusableInTouchMode());
+        assertFalse(container.isFocusableInTouchMode());
         assertFalse(container.isEnabled());
         assertFalse(container.isCounterEnabled());
     }


### PR DESCRIPTION
## Descripción

**Helper text:** al setearlo por código se oculta al escribir. También cuando se setea un error y después se hace setError(null) no se vuelve a mostrar, esto ocurre tanto para el helper seteado por XML como por código.
Se hacen las modificaciones para que funcione y permanezca en todos los casos. 

## ¿Por qué necesitamos este cambio?