### PR TITLE
Fix TextField's character counter's visibility being incorrectly chan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Cambiado
 - Al habilitar / desabilitar el TextField se aplica el focusableInTouchMode al editText en lugar del container para permitir pasar foco de un input al siguiente por teclado.
 
+## Arreglado
+- Ahora el parámetro charactersCountVisible de TextField se puede setear correctamente por XML, hacer setEnable() a un TextField ya no modifica la visibilidad del contador de caracteres.
+
 # v8.2.0
 ## Agregado
 - Se vuelve a agregar metodo TypefaceHelper.getTypeface(context, font, callback) por compatabilidad. Se depreca su uso por TypefaceHelper.getFontTypeface(context, font)

--- a/exampleApp/src/main/res/layout/activity_textfield.xml
+++ b/exampleApp/src/main/res/layout/activity_textfield.xml
@@ -61,7 +61,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:ui_textFieldHint="Title"
-            app:ui_textFieldMaxCharacters="20"/>
+            app:ui_textFieldMaxCharacters="20"
+            app:ui_textFieldCharactersCountVisible="true" />
 
         <TextView
             android:layout_width="wrap_content"

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -514,7 +514,7 @@ public final class TextField extends LinearLayout {
             final InputFilter[] filterArray = new InputFilter[1];
             filterArray[0] = new InputFilter.LengthFilter(maxCharacters);
             input.setFilters(filterArray);
-            setCharactersCountVisible(!hasHelper);
+            setCharactersCountVisible(!hasHelper && charactersCountVisible);
             container.setCounterMaxLength(maxChars);
         }
     }
@@ -784,11 +784,9 @@ public final class TextField extends LinearLayout {
         if (enabled) {
             input.setFocusableInTouchMode(true);
             container.setEnabled(true);
-            setMaxCharacters(maxCharacters);
         } else {
             input.setFocusableInTouchMode(false);
             container.setEnabled(false);
-            setCharactersCountVisible(false);
             setError(null);
         }
     }

--- a/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
+++ b/ui/src/test/java/com/mercadolibre/android/ui/widgets/TextFieldTest.java
@@ -422,6 +422,7 @@ public class TextFieldTest {
         textField.setText("text");
         textField.setLabel("label");
         textField.setError("error");
+        textField.setCharactersCountVisible(true);
         textField.setMaxCharacters(12);
         textField.setMaxLines(3);
         textField.setEnabled(true);
@@ -495,7 +496,7 @@ public class TextFieldTest {
         assertEquals("errorText", "error", textField.getError());
         assertEquals("linesNumber", 3, editText.getMaxLines());
         assertEquals("charactersNumber", 12, container.getCounterMaxLength());
-        assertEquals("charactersVisible ", 1, container.isCounterEnabled() ? 1 : 0);
+        assertEquals("charactersVisible ", 0, container.isCounterEnabled() ? 1 : 0);
         assertEquals("hint", "hint", textField.getHint());
         assertEquals("enabled", 1, textField.isEnabled() ? 1 : 0);
         parcelMemory.clear();


### PR DESCRIPTION
…ged by some methods, fix tests

## Descripción
Se arreglan comportamientos incorrectos de TextField respecto al contador de caracteres.

## ¿Por qué necesitamos este cambio?
No se podía setear correctamente el atributo charactersCountVisible por XML y hacer "setEnabled()" al TextField cambiaba la visibilidad del contador de caracteres.