### PR TITLE
 Fix: Showing counter and helper at the same time

### DIFF
--- a/exampleApp/src/main/res/layout/activity_textfield.xml
+++ b/exampleApp/src/main/res/layout/activity_textfield.xml
@@ -67,6 +67,18 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="TextField with max characters and helper"/>
+        <com.mercadolibre.android.ui.widgets.TextField
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:ui_textFieldHint="Title"
+            app:ui_textFieldHelperText="Helper"
+            app:ui_textFieldMaxCharacters="20"
+            app:ui_textFieldCharactersCountVisible="true" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="TextField with max lines"/>
 
         <com.mercadolibre.android.ui.widgets.TextField

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -18,7 +18,6 @@ import android.support.annotation.StringRes;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.view.ViewCompat;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -61,7 +60,6 @@ public final class TextField extends LinearLayout {
     private TextInputLayout container;
     private TextInputEditText input;
     private TextView label;
-    private TextView helper;
 
     /**
      * Attributes
@@ -135,7 +133,6 @@ public final class TextField extends LinearLayout {
         container = (TextInputLayout) findViewById(R.id.ui_text_field_input_container);
         input = (TextInputEditText) findViewById(R.id.ui_text_field_input);
         label = (TextView) findViewById(R.id.ui_text_field_label);
-        helper = (TextView) findViewById(R.id.ui_text_field_helper);
 
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.TextField, defStyleAttr, 0);
         textAlign = a.getInt(R.styleable.TextField_ui_textFieldAlign, LEFT);
@@ -350,17 +347,15 @@ public final class TextField extends LinearLayout {
     public void setHelper(@Nullable final String helpText) {
         final boolean isEmpty = TextUtils.isEmpty(helpText);
         helperText = helpText;
-        helper.setText(helperText);
+        container.setHelperText(helperText);
+        container.setHelperTextEnabled(true);
+        container.setGravity(textAlign);
         hasHelper = !isEmpty;
         if (!enabled || isEmpty) {
             hideHelper();
             return;
         }
-        ViewCompat.setPaddingRelative(helper, 0,
-            0, 0, input.getPaddingBottom());
         changeErrorVisibility(false);
-        helper.setGravity(textAlign);
-        helper.setVisibility(VISIBLE);
         isShowingHelper = true;
     }
 
@@ -515,7 +510,7 @@ public final class TextField extends LinearLayout {
             final InputFilter[] filterArray = new InputFilter[1];
             filterArray[0] = new InputFilter.LengthFilter(maxCharacters);
             input.setFilters(filterArray);
-            setCharactersCountVisible(!hasHelper && charactersCountVisible);
+            setCharactersCountVisible(charactersCountVisible);
             container.setCounterMaxLength(maxChars);
         }
     }
@@ -795,7 +790,7 @@ public final class TextField extends LinearLayout {
     }
 
     private void hideHelper() {
-        helper.setVisibility(GONE);
+        container.setHelperTextEnabled(false);
         isShowingHelper = false;
     }
 

--- a/ui/src/main/res/layout/ui_layout_textfield.xml
+++ b/ui/src/main/res/layout/ui_layout_textfield.xml
@@ -34,14 +34,4 @@
             tools:hint="Hint" />
 
     </android.support.design.widget.TextInputLayout>
-
-    <TextView
-        android:id="@+id/ui_text_field_helper"
-        style="@style/MeliTextField.HelperText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:layout_marginLeft="@dimen/ui_textfield_label_margin_left"
-        android:layout_marginStart="@dimen/ui_textfield_label_margin_left"
-        tools:text="Helper Text" />
 </merge>


### PR DESCRIPTION
## Descripción
Se cambia comportamiento del helper y el contador para que ambos puedan mostrarse al mismo tiempo
**Disclaimer**: el helper siempre se mostrara al lado izquierdo y el contador al lado derecho 

Propuesta de cambio UX 
<img width="222" alt="Captura de pantalla 2020-05-13 a la(s) 15 54 48" src="https://user-images.githubusercontent.com/46686534/81858691-1ca99280-9532-11ea-9895-e90ef3cdae77.png">



|SDK|Antes|Despues|
| -------- |:----------- |:-----------:|
|28|![Screenshot_20200513_155218_temp](https://user-images.githubusercontent.com/46686534/81858544-ec61f400-9531-11ea-8034-7871d565296f.jpg)|![Screenshot_20200513_154859_temp](https://user-images.githubusercontent.com/46686534/81858281-7cec0480-9531-11ea-8293-26cc180deb60.jpg)|
|19|![sell_wiget](https://user-images.githubusercontent.com/46686534/82358503-9b8c4880-99d4-11ea-95f6-af7e1e7498b8.gif)|![sell_wiget_new](https://user-images.githubusercontent.com/46686534/82358508-9fb86600-99d4-11ea-81df-823fc9c872f5.gif)|


## ¿Por qué necesitamos este cambio?
Para que podamos mostrar el helper y el contador al mismo tiempo 