### PR TITLE
Añadido soporte de accesibilidad a widget MeliDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.10.0
+## Agregado
+- Se agregó soporte de accesibilidad a widget MeliDialog
+
 # v8.9.0
 ## Eliminado
 - Se removio calligraphy de android:ui

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -530,12 +530,13 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
     /**
      * Gets contentDescription for close button (for accessibility)
      */
+    @Nullable
     protected String getCloseButtonContentDescription() {
         CharSequence closeButtonContentDescription = root.findViewById(R.id.ui_melidialog_close_button).getContentDescription();
-        if (closeButtonContentDescription == null)
+        if (closeButtonContentDescription == null) {
             return null;
-        else
-            return closeButtonContentDescription.toString();
+        } else {
+            return closeButtonContentDescription.toString(); }
     }
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -531,8 +531,11 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
      * Gets contentDescription for close button (for accessibility)
      */
     protected String getCloseButtonContentDescription() {
-        closeButton = root.findViewById(R.id.ui_melidialog_close_button);
-        return closeButton.getContentDescription().toString();
+        CharSequence closeButtonContentDescription = root.findViewById(R.id.ui_melidialog_close_button).getContentDescription();
+        if (closeButtonContentDescription == null)
+            return null;
+        else
+            return closeButtonContentDescription.toString();
     }
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -526,4 +526,11 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
                 + ", dismissed=" + dismissed
                 + '}';
     }
+
+    /**
+     * Sets a content description for close button (for accessibility)
+     */
+    public void setCloseButtonContentDescription(String contentDescription){
+        closeButton.setContentDescription(contentDescription);
+    }
 }

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -528,9 +528,18 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
     }
 
     /**
-     * Sets a content description for close button (for accessibility)
+     * Gets contentDescription for close button (for accessibility)
      */
-    public void setCloseButtonContentDescription(String contentDescription){
+    protected String getCloseButtonContentDescription() {
+        closeButton = root.findViewById(R.id.ui_melidialog_close_button);
+        return closeButton.getContentDescription().toString();
+    }
+
+    /**
+     * Sets contentDescription for close button (for accessibility)
+     */
+    protected void setCloseButtonContentDescription(String contentDescription) {
+        closeButton = root.findViewById(R.id.ui_melidialog_close_button);
         closeButton.setContentDescription(contentDescription);
     }
 }


### PR DESCRIPTION
## Descripción

- Se añadieron getter y setter para contentDescription del componente ui_melidialog_close_button

## ¿Por qué necesitamos este cambio?

- El cambio es necesario por motivos de accesibilidad, ya que actualmente el botón lee "Sin Etiquetar, Botón" al pasar un lector de pantalla. Con la modificación se abre la posibilidad de que cualquiera que use el componente pueda setear que es lo que los lectores de pantalla (como TalkBack) "dirán" al pararse en ese botón.