### PR TITLE
Fix dismissAllowingStateLoss en MeliDialog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.11.0
+## Arreglado
+- Se corrige fix en MeliDialog, al hacer dismiss del dialog crasheaba por estar destuida la instancia del fragment.
+
 # v8.10.0
 ## Agregado
 - Se agregó soporte de accesibilidad a widget MeliDialog

--- a/exampleApp/src/main/java/com/mercadolibre/android/ui/example/ui/widgets/dialog/DialogActivity.java
+++ b/exampleApp/src/main/java/com/mercadolibre/android/ui/example/ui/widgets/dialog/DialogActivity.java
@@ -46,6 +46,7 @@ public class DialogActivity extends BaseActivity implements DummyInterface {
         final FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         final MeliDialog frag = new DummyListDialogWithTitle();
         frag.show(ft, TAG);
+
     }
 
     public void showDialogWithListNoTitle(final View view) {
@@ -67,4 +68,3 @@ public class DialogActivity extends BaseActivity implements DummyInterface {
         finish();
     }
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,6 @@ org.gradle.workers.max=8
 
 android.enableUnitTestBinaryResources=false
 
-
 ##################################################################################
 # Publishing
 ##################################################################################
@@ -36,7 +35,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=8.10.0
+libraryVersion=8.11.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -33,7 +33,7 @@ import com.mercadolibre.android.ui.R;
  *
  * @since 6/4/16
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings("PMD")
 public abstract class MeliDialog extends DialogFragment implements KeyboardEventCallback {
 
     /**

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/MeliDialog.java
@@ -96,6 +96,12 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
         return root;
     }
 
+    @Override
+    public void onDestroy() {
+        MeliDialog.super.dismissAllowingStateLoss();
+        super.onDestroy();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -107,7 +113,9 @@ public abstract class MeliDialog extends DialogFragment implements KeyboardEvent
                 root.postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        MeliDialog.super.dismissAllowingStateLoss();
+                        if (isAdded()) {
+                            MeliDialog.super.dismissAllowingStateLoss();
+                        }
                     }
                 }, FADE_ANIMATION_DURATION);
             } else {


### PR DESCRIPTION
## Descripción
Se arreglo el fix de MeliDialog. Crasheaba cuando se llamaba a dismissAllowingStateLoss().