### PR TITLE
[TextField] Agregamos soporte para appearance de helper text

### DIFF
--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -15,6 +15,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
@@ -357,6 +358,15 @@ public final class TextField extends LinearLayout {
         }
         changeErrorVisibility(false);
         isShowingHelper = true;
+    }
+
+    /**
+     * Setter for the helper text appearance
+     *
+     * @param appearance the text
+     */
+    public void setHelperTextAppearance(@StyleRes final int appearance) {
+        container.setHelperTextTextAppearance(appearance);
     }
 
     private void changeErrorVisibility(final boolean isVisible) {

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -363,7 +363,7 @@ public final class TextField extends LinearLayout {
     /**
      * Setter for the helper text appearance
      *
-     * @param appearance the text
+     * @param appearance the appearance (style)
      */
     public void setHelperTextAppearance(@StyleRes final int appearance) {
         container.setHelperTextTextAppearance(appearance);

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -15,7 +15,6 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.annotation.StyleRes;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
@@ -149,6 +148,7 @@ public final class TextField extends LinearLayout {
         hasHelper = !TextUtils.isEmpty(helperText);
 
         container.setErrorTextAppearance(R.style.MeliTextField_ErrorText);
+        container.setHelperTextTextAppearance(R.style.MeliTextField_HelperText);
         container.setHintTextAppearance(R.style.MeliTextField_Label);
 
         init();
@@ -358,15 +358,6 @@ public final class TextField extends LinearLayout {
         }
         changeErrorVisibility(false);
         isShowingHelper = true;
-    }
-
-    /**
-     * Setter for the helper text appearance
-     *
-     * @param appearance the appearance (style)
-     */
-    public void setHelperTextAppearance(@StyleRes final int appearance) {
-        container.setHelperTextTextAppearance(appearance);
     }
 
     private void changeErrorVisibility(final boolean isVisible) {

--- a/ui/src/main/res/values/styles-textfield.xml
+++ b/ui/src/main/res/values/styles-textfield.xml
@@ -17,7 +17,7 @@
     </style>
 
     <style name="MeliTextField.HelperText">
-        <item name="android:textAppearance">@style/MLFont.Regular</item>
+        <item name="android:textAppearance">@style/MLFont.Bold.Semi</item>
         <item name="android:textColor">@color/ui_components_dark_grey_color</item>
         <item name="android:textSize">@dimen/ui_fontsize_xsmall</item>
     </style>


### PR DESCRIPTION
## Descripción
| Matcheando estilo de helper text y error text (FIX) | Con distinto estilo (se desplazan las demás vistas) (ERROR ACTUAL)|
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/49948473/85172241-0389b500-b247-11ea-9a3f-5fb01f387426.gif" width="260" height="480">  | <img src="https://user-images.githubusercontent.com/49948473/85172387-55cad600-b247-11ea-9aaa-96e1a6a48dc1.gif" width="260" height="480"> |

## ¿Por qué necesitamos este cambio?
- Para poder matchear con los styles del error del TextField  