### PR TITLE
Removing allowBackup attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.13.0
+## Cambiado
+- Se elimina el atributo allowBackup=true del Manifest, para que tome el valor establecido en las apps.
+
 # v8.12.0
 ## Cambiado
 - Se agrego el android: a las properties de background en el xml y se agrego un null check en el

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=8.12.0
+libraryVersion=8.13.0
 
 ##################################################################################
 # Project setup

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.mercadolibre.android.ui">
 
     <application
-        android:allowBackup="true"
         android:supportsRtl="true" />
 
 </manifest>

--- a/ui_legacy/src/main/AndroidManifest.xml
+++ b/ui_legacy/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <!--<uses-sdk-->
         <!--tools:node="replace" />-->
 
-    <application android:allowBackup="true">
+    <application>
 
         <activity android:name="com.mercadolibre.android.ui.activities.LayoutUtilsActivity">
         </activity>


### PR DESCRIPTION
## Descripción
Se remueve atributo de allowBackup, ya que colisiona con una lib que usamos en Cards que requiere que dicho atributo sea falso, ya que encripta datos sensibles.
Al removerlo, la lib de ui tomaría el valor de allowBackup de las apps directamente