### PR TITLE
Corrigiendo comportamiento a TextInputLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v8.14.0
 ## Cambiado
 - Se corrige el gravity del helper en el TextField, cuando esta centrado.
+- Se agrega estilo al counter del TextField.
 
 # v8.13.0
 ## Cambiado

--- a/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
+++ b/ui/src/main/java/com/mercadolibre/android/ui/widgets/TextField.java
@@ -28,6 +28,7 @@ import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
@@ -49,6 +50,8 @@ import static java.lang.Integer.MAX_VALUE;
  */
 @SuppressWarnings("PMD")
 public final class TextField extends LinearLayout {
+
+    public static final double WIDTH_TEXTFIELD_FIX = 0.8;
 
     /* default */ String helperText;
     /* default */ boolean isShowingError;
@@ -361,11 +364,13 @@ public final class TextField extends LinearLayout {
     }
 
     private void setHelperGravity() {
+        final TextView helperView = container.findViewById(R.id.textinput_helper_text);
         if (textAlign == CENTER || textAlign == android.view.Gravity.CENTER_HORIZONTAL) {
-                TextView helperView = container.findViewById(R.id.textinput_helper_text);
-                FrameLayout errorViewParent = (FrameLayout) helperView.getParent();
-                errorViewParent.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
-                helperView.setGravity(textAlign);
+            final FrameLayout helperViewParent = (FrameLayout) helperView.getParent();
+            helperViewParent.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+            helperView.setGravity(textAlign);
+        } else if (container.isCounterEnabled()) {
+            setWidthToTextInputLayout(helperView, WIDTH_TEXTFIELD_FIX);
         }
     }
 
@@ -413,18 +418,38 @@ public final class TextField extends LinearLayout {
             }
 
             final TextView errorView = (TextView) container
-                .findViewById(android.support.design.R.id.textinput_error);
-
+                    .findViewById(android.support.design.R.id.textinput_error);
             TypefaceHelper.setTypeface(errorView, Font.SEMI_BOLD);
-            final FrameLayout.LayoutParams errorViewParams =
-                new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
-            errorViewParams.gravity = textAlign;
-            errorView.setGravity(textAlign);
-            errorView.setLayoutParams(errorViewParams);
+
+            if (textAlign == CENTER || textAlign == android.view.Gravity.CENTER_HORIZONTAL) {
+                final FrameLayout.LayoutParams errorViewParams =
+                        new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+                errorViewParams.gravity = textAlign;
+                errorView.setGravity(textAlign);
+                errorView.setLayoutParams(errorViewParams);
+            } else if(container.isCounterEnabled()){
+                setWidthToTextInputLayout(errorView, WIDTH_TEXTFIELD_FIX);
+            }
         }
 
         container.setError(error);
         container.setErrorEnabled(!isEmpty);
+    }
+
+    /**
+     * This is a fix to android helper and error, when counter is showing
+     */
+    private void setWidthToTextInputLayout(final TextView textView, final double width) {
+        container.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                final int widthLayout = (int) (container.getWidth() * width);
+                final FrameLayout.LayoutParams viewParams =
+                        new FrameLayout.LayoutParams(widthLayout, FrameLayout.LayoutParams.WRAP_CONTENT);
+                textView.setLayoutParams(viewParams);
+                container.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+            }
+        });
     }
 
     /**

--- a/ui/src/main/res/layout/ui_layout_textfield.xml
+++ b/ui/src/main/res/layout/ui_layout_textfield.xml
@@ -20,7 +20,8 @@
         android:layout_centerVertical="true"
         android:orientation="horizontal"
         app:errorTextAppearance="@style/MeliTextField.ErrorText"
-        app:hintTextAppearance="@style/MeliTextField.Label">
+        app:hintTextAppearance="@style/MeliTextField.Label"
+        app:counterTextAppearance="@style/MeliTextField.CounterText">
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/ui_text_field_input"


### PR DESCRIPTION
## Descripción
Se agrega estilo al counter y se hace cambio al centrado del error para no mostrar comportamiento erroneo al momento de mostrar helper y contador 

Por otro lado el componente **android.support.design.widget.TextInputLayout** se rompe visualmente cuando el helper ó el error son largos, hasta llegar a soslayar el contador, por esto hemos agregado un **addOnGlobalLayoutListener** para agregar el tamaño al helper o el error 

|Antes|Despues|
| -------- |:----------- |
|![Screenshot_1593566482](https://user-images.githubusercontent.com/46686534/86193409-d926da00-bb19-11ea-9ce1-49792f24ebfc.png)|![Screenshot_1593561249](https://user-images.githubusercontent.com/46686534/86193505-0e332c80-bb1a-11ea-8b8e-76eaf3f2d05e.png)| 
|![Screenshot_1593566487](https://user-images.githubusercontent.com/46686534/86193445-ee036d80-bb19-11ea-9c12-406daaf39be4.png)|![Screenshot_1593636526](https://user-images.githubusercontent.com/46686534/86290092-d4fec900-bbba-11ea-8393-9ef0bfbb01c7.png)|
|![Screenshot_1593566493](https://user-images.githubusercontent.com/46686534/86193456-f65ba880-bb19-11ea-97bc-6bbf4656ff16.png)|![Screenshot_1593636535](https://user-images.githubusercontent.com/46686534/86290101-daf4aa00-bbba-11ea-9ad6-4720c5d56885.png)|
|![Screenshot_1593566497](https://user-images.githubusercontent.com/46686534/86193463-fb205c80-bb19-11ea-8dd8-672048430019.png)|![Screenshot_1593636545](https://user-images.githubusercontent.com/46686534/86290109-dfb95e00-bbba-11ea-83ab-cbabc95988d9.png)|

|Antes|Despues|
| -------- |:----------- |
|![Screenshot_20200623_195350](https://user-images.githubusercontent.com/46686534/85479320-eb3dd100-b58b-11ea-8842-1fa6ba989470.jpg)|![Screenshot_20200701_173634](https://user-images.githubusercontent.com/46686534/86294588-d6cc8a80-bbc2-11ea-9f21-a396e11db4d0.jpg)|