### PR TITLE
fix android x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.16.0
+## Cambiado
+- Se corrigió un error con los ID de xml que generaban incompatibilidad con la migración de Android X desde otras librerias
+
 # v8.15.0
 ## Agregado
 - Agregamos contentDescription al Input de TextField

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=8.15.0
+libraryVersion=LOCAL-8.17.0
 
 ##################################################################################
 # Project setup

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ libraryGroupId=com.mercadolibre.android
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=LOCAL-8.17.0
+libraryVersion=8.16.0
 
 ##################################################################################
 # Project setup

--- a/ui_legacy/src/main/res/layout/list_preference_layout.xml
+++ b/ui_legacy/src/main/res/layout/list_preference_layout.xml
@@ -10,7 +10,7 @@
     android:background="?android:attr/selectableItemBackground">
 
     <ImageView
-        android:id="@+android:id/icon"
+        android:id="@android:id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center" />
@@ -24,13 +24,13 @@
         android:layout_weight="1">
 
         <TextView
-            android:id="@+android:id/title"
+            android:id="@android:id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/MLPreference.Item"/>
 
         <TextView
-            android:id="@+android:id/summary"
+            android:id="@android:id/summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@android:id/title"
@@ -41,7 +41,7 @@
 
     <!-- Preference should place its actual preference widget here. -->
     <LinearLayout
-        android:id="@+android:id/widget_frame"
+        android:id="@android:id/widget_frame"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center_vertical"

--- a/ui_legacy/src/main/res/layout/preference_category.xml
+++ b/ui_legacy/src/main/res/layout/preference_category.xml
@@ -2,4 +2,4 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     style="?android:attr/listSeparatorTextViewStyle"
     android:layout_marginTop="5dp"
-    android:id="@+android:id/title" />
+    android:id="@android:id/title" />


### PR DESCRIPTION
## ¿Por qué necesitamos este cambio?
Identificamos una incompatibilidad con las versiones de la biblioteca que migraron a Android x, lo que evitó la compilación de la wallet.